### PR TITLE
docs: refresh README header, add badges + MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andriy Kalashnykov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,51 @@
-# dapr-go-workflow-k8s
+# Radius Recipes on Dapr Durable Workflows — Go Reference Service
 
 [![CI](https://github.com/AndriyKalashnykov/dapr-go-workflow-k8s/actions/workflows/ci.yml/badge.svg)](https://github.com/AndriyKalashnykov/dapr-go-workflow-k8s/actions/workflows/ci.yml)
+[![Hits](https://hits.sh/github.com/AndriyKalashnykov/dapr-go-workflow-k8s.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/dapr-go-workflow-k8s/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/dapr-go-workflow-k8s)
 [![Go Reference](https://pkg.go.dev/badge/github.com/AndriyKalashnykov/dapr-go-workflow-k8s.svg)](https://pkg.go.dev/github.com/AndriyKalashnykov/dapr-go-workflow-k8s)
 
-A Go service that drives **[Radius](https://radapp.io/) Recipes** via **[Dapr](https://dapr.io/) durable workflows**. It exposes a small REST API that schedules Dapr workflows; each workflow orchestrates activities to provision (or tear down) a PostgreSQL database and its backing Kubernetes resources, then returns recipe outputs (values, secrets, resources) in the shape Radius expects.
+Reference Go service that drives **[Radius](https://radapp.io/) Recipes** through **[Dapr](https://dapr.io/) durable workflows**. The **runtime surface** is a small REST API that schedules durable workflows (`durabletask-go` registry + `dapr/go-sdk`) to provision or tear down a PostgreSQL database and its backing Kubernetes resources, returning recipe outputs (`values`, `secrets`, `resources`) in the shape Radius expects; the **delivery surface** ships a distroless image, a real Dapr-sidecar end-to-end test (`make e2e`), a `mise`-pinned toolchain, a `static-check` gate (golangci-lint, govulncheck, gitleaks, Trivy, hadolint, actionlint/shellcheck, mermaid-lint), and a GitHub Actions pipeline with a blocking Trivy scan and cosign keyless image signing, with Renovate-managed dependencies.
 
 > **Note:** the workflow activities are demo stubs — they log and simulate work rather than calling real Kubernetes / PostgreSQL APIs. Treat this repository as a Radius-recipe-on-Dapr-workflows scaffold; wiring the activities to real backends is the intended extension point.
+
+| Component | Technology |
+|-----------|------------|
+| Language | Go 1.26 |
+| Workflow engine | [Dapr durable workflows](https://docs.dapr.io/developing-applications/building-blocks/workflow/) via `dapr/durabletask-go` v0.12 |
+| Dapr SDK | `dapr/go-sdk` v1.15 (runtime ≥ 1.18) |
+| HTTP | `net/http` + [go-chi/chi](https://github.com/go-chi/chi) router |
+| Recipe contract | Radius Recipe `Context` / `Result` types (`pkg/recipes`) |
+| State store | PostgreSQL (Dapr `state.postgresql` component) |
+| Container | `gcr.io/distroless/static-debian12:nonroot` (multi-stage build) |
+| CI / security | GitHub Actions, Trivy, gitleaks, govulncheck, cosign keyless signing |
+| Toolchain / deps | mise-pinned tools, Renovate |
+
+## Quick Start
+
+```bash
+make deps             # install toolchain + quality tools (via mise)
+make ci               # full local pipeline: format + static-check + test + coverage + build
+
+# Run the workflow end to end (needs Docker + the Dapr CLI):
+make postgres-start   # start a local PostgreSQL state store
+make run              # run the app under a Dapr sidecar
+./start-workflow.sh   # health-check, PUT a workflow, poll until it completes
+make postgres-stop    # tear down PostgreSQL
+```
+
+## Prerequisites
+
+| Tool | Version | Purpose | Install |
+|------|---------|---------|---------|
+| [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration | per-platform |
+| [Git](https://git-scm.com/) | latest | Source control | per-platform |
+| [mise](https://mise.jdx.dev) | latest | Manages the Go toolchain and all quality/security tools | `curl https://mise.run \| sh` (or `make deps`) |
+| [Docker](https://docs.docker.com/get-docker/) | latest | Local PostgreSQL + container image builds | per-platform |
+| [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) | latest | Running the app with a sidecar | `dapr init` |
+
+`make deps` bootstraps mise and installs the Go toolchain plus `golangci-lint`, `gitleaks`, `trivy`, `hadolint`, `actionlint`, `shellcheck`, `act`, `goreleaser`, and `govulncheck` — all pinned in `.mise.toml`.
 
 ## Architecture
 
@@ -40,7 +80,7 @@ flowchart LR
   daprd -->|"workflow / actor state"| pg
 ```
 
-```
+```text
 cmd/
   main.go          - Application entrypoint (worker + HTTP server)
   healthcheck/     - Dependency-free container HEALTHCHECK probe
@@ -51,55 +91,6 @@ pkg/
   workflows/       - Durable workflow definitions (PostgreSQL databases put/delete)
 components/        - Dapr component configs (statestore, tracing config)
 db/               - PostgreSQL initialization script
-```
-
-## Prerequisites
-
-| Tool | Purpose | Install |
-|------|---------|---------|
-| [mise](https://mise.jdx.dev) | Manages the Go toolchain and all quality/security tools | `curl https://mise.run \| sh` (or `make deps`) |
-| [Docker](https://docs.docker.com/get-docker/) | Local PostgreSQL + container image builds | per-platform |
-| [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) | Running the app with a sidecar | `dapr init` |
-
-`make deps` bootstraps mise and installs the Go toolchain plus `golangci-lint`, `gitleaks`, `trivy`, `hadolint`, `actionlint`, `shellcheck`, `act`, `goreleaser`, and `govulncheck` — all pinned in `.mise.toml`.
-
-## Quick Start
-
-```bash
-make deps             # install toolchain + quality tools (via mise)
-make ci               # full local pipeline: format + static-check + test + coverage + build
-
-# Run the workflow end to end (needs Docker + the Dapr CLI):
-make postgres-start   # start a local PostgreSQL state store
-make run              # run the app under a Dapr sidecar
-./start-workflow.sh   # health-check, PUT a workflow, poll until it completes
-make postgres-stop    # tear down PostgreSQL
-```
-
-## Make Targets
-
-```
-make deps             - Install toolchain (Go + quality tools) via mise
-make build            - Build linux/amd64 binary to ./cmd/main
-make test             - Run unit tests with race detector and coverage
-make coverage-check   - Verify coverage meets COVERAGE_THRESHOLD (default 40%)
-make format           - Auto-format Go source (gofmt + goimports)
-make lint             - golangci-lint + go mod tidy check + hadolint
-make lint-ci          - Lint workflows (actionlint) and shell scripts (shellcheck)
-make vulncheck        - govulncheck dependency vulnerability scan
-make secrets          - gitleaks secret scan
-make trivy-fs         - Trivy filesystem scan (vuln, secret, misconfig)
-make static-check     - Composite quality gate (alignment + all of the above)
-make ci               - Full local CI pipeline
-make ci-run           - Run the GitHub Actions workflow locally via act
-make e2e              - End-to-end test: run the workflow through a real Dapr sidecar
-make run              - Run the app via the Dapr sidecar
-make postgres-start   - Start a local PostgreSQL container
-make postgres-stop    - Stop the local PostgreSQL container
-make image-build      - Build the container image
-make image-push       - Push the container image to ghcr.io
-make release          - Create and push a new release tag (vN.N.N)
-make help             - List all targets
 ```
 
 ## Configuration
@@ -113,6 +104,65 @@ All operator-tunable values are documented in [`.env.example`](.env.example). Co
 | `DAPR_GRPC_PORT` | `50001` | Dapr sidecar gRPC port |
 | `POSTGRES_PASSWORD` | `daprrulz` | Local dev PostgreSQL password |
 | `POSTGRES_PORT` | `5432` | Local dev PostgreSQL port |
+
+## Make Targets
+
+Run `make help` to see all targets.
+
+### Build & Run
+
+| Target | Description |
+|--------|-------------|
+| `make deps` | Install the toolchain (Go + quality tools) via mise |
+| `make deps-check` | Show the Go version and mise-managed tool status |
+| `make get` | Download and tidy dependencies |
+| `make update` | Update dependencies to latest versions |
+| `make build` | Build the linux/amd64 binary to `./cmd/main` |
+| `make run` | Run the app via the Dapr sidecar |
+| `make clean` | Remove build artifacts |
+
+### Testing
+
+| Target | Description |
+|--------|-------------|
+| `make test` | Unit tests with race detector + coverage (seconds; `-short` skips the 5s backup sim) |
+| `make coverage-check` | Verify coverage meets `COVERAGE_THRESHOLD` (default 40%) |
+| `make e2e-deps` | Ensure the Dapr control plane (placement + scheduler) is up |
+| `make e2e` | End-to-end: run the workflow through a real Dapr sidecar (minutes; needs Docker + Dapr CLI) |
+
+### Code Quality
+
+| Target | Description |
+|--------|-------------|
+| `make format` | Auto-format Go source (gofmt + goimports via golangci-lint) |
+| `make check-go-alignment` | Verify the Go version matches across `go.mod`, `.mise.toml`, `Dockerfile` |
+| `make lint` | golangci-lint + `go mod tidy` check + hadolint + script `+x` guard |
+| `make lint-ci` | Lint GitHub Actions workflows (actionlint) and shell scripts (shellcheck) |
+| `make vulncheck` | govulncheck dependency vulnerability scan |
+| `make secrets` | gitleaks secret scan |
+| `make trivy-fs` | Trivy filesystem scan (vuln, secret, misconfig) |
+| `make mermaid-lint` | Validate Mermaid diagrams in markdown (same engine GitHub renders with) |
+| `make static-check` | Composite quality gate (alignment + workflow lint + lint + vuln + secrets + trivy + mermaid) |
+
+### Local Infra & Containers
+
+| Target | Description |
+|--------|-------------|
+| `make postgres-start` | Start a local PostgreSQL container (state store) |
+| `make postgres-stop` | Stop the local PostgreSQL container |
+| `make image-build` | Build the container image |
+| `make image-run` | Run the container image locally (needs a healthy Dapr sidecar) |
+| `make image-stop` | Stop the local container |
+| `make image-push` | Push the container image to the registry |
+
+### CI & Release
+
+| Target | Description |
+|--------|-------------|
+| `make ci` | Full local CI pipeline (mirrors GitHub Actions) |
+| `make ci-run` | Run the GitHub Actions workflow locally via [act](https://github.com/nektos/act) |
+| `make release` | Create and push a new release tag (`vN.N.N`) |
+| `make version` | Print the current version (git tag) |
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

Refreshes the README header for consistency with the GitHub **About** field and adds the missing header badges.

- **Title** aligned to the About leading clause: `# Radius Recipes on Dapr Durable Workflows — Go Reference Service`
- **Badges**: added Hits, License (MIT), and Renovate alongside the existing CI + Go Reference
- **Description** rewritten in runtime/delivery surface-split form, naming the full toolchain
- **Tech Stack** table added
- **Section order** fixed: Quick Start → Prerequisites → Architecture → Configuration → Make Targets → CI/CD
- **Make Targets** converted to grouped tables covering every Makefile target
- **LICENSE**: added MIT (enables the License badge)

## Test plan
- [x] `make mermaid-lint` passes
- [x] No placeholder/secret leaks; fences balanced
- [x] Every Makefile target appears in the README
- [ ] CI `ci-pass` green