### PR TITLE
feat: make PostgresSQLDatabasesPut update-idempotent + bound DDL statements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ PG_ADMIN_DB=postgres
 PG_SSLMODE=disable
 # Admin connection dial timeout (seconds).
 PG_CONNECT_TIMEOUT_SECONDS=10
+# Per-statement timeout for a single DDL (CREATE/DROP ROLE/DATABASE), so a
+# statement blocked on a lock cannot hang the workflow activity indefinitely.
+PG_OP_TIMEOUT_SECONDS=30
 # Directory for best-effort pg_dump backups on delete (used only if pg_dump is
 # on PATH). Defaults to the OS temp dir when unset.
 # PG_BACKUP_DIR=/tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,22 @@ Go service that drives **Radius Recipes** via **Dapr durable workflows**. It exp
 
 > **The activities call real backends.** `pkg/activities/postgres.go` runs real DDL via **pgx/v5** against a PostgreSQL admin endpoint (`CREATE ROLE` / `CREATE DATABASE` / `DROP … WITH (FORCE)` / `DROP ROLE`), and `pkg/activities/kubernetes.go` publishes a real **Service + Secret** binding into the cluster via **client-go** (removed on delete). The returned recipe URI is genuinely connectable (built with `url.URL` escaping via `activities.ConnectionURI`). Backend clients are constructed through injectable package-level constructors (`newPGAdmin`, `newKubeBinder`) so activities are unit-tested hermetically against fakes; the real path is exercised by `make e2e`. The remaining extension point is swapping the Kubernetes binding for a full workload deploy (Deployment/StatefulSet) and wiring cloud-provider scopes (`recipes.ProviderAzure`/`ProviderAWS`).
 
+### Update idempotency & timeouts
+
+`PostgresSQLDatabasesPut` is **update-idempotent**: it reads the prior
+`status.binding` (`username`/`database`) from the recipe context — the same shape
+`PostgresSQLDatabasesDelete` reads — and reuses those role/database names on a
+redeploy (the role password is rotated, the database ensured) instead of creating
+fresh objects and orphaning the old ones. A first Put (empty binding) generates
+fresh unique names.
+
+Individual DDL statements are bounded by `PG_OP_TIMEOUT_SECONDS` (default 30s) so a
+statement blocked on a lock cannot hang the activity; the admin dial is bounded
+separately by `PG_CONNECT_TIMEOUT_SECONDS`.
+
 ### Known limitations (scaffold)
 
-- **`PostgresSQLDatabasesPut` is not update-idempotent.** Each Put provisions a fresh role + database (unique random suffix) instead of reading and reusing a prior binding from `Resource.Properties.status.binding`. A redeploy of the same resource creates new objects and leaves the old ones for `PostgresSQLDatabasesDelete` to reclaim. A production recipe would reuse the existing binding on update.
 - **Delete's backup is best-effort.** `DeletePostgresDatabase` runs `pg_dump` only if the binary is on `PATH`; a missing/failed backup is logged (`Warn`) and the `DROP DATABASE … WITH (FORCE)` proceeds regardless — the drop is the required side effect, the backup is advisory.
-- **Only the admin dial is timeout-bounded.** `PG_CONNECT_TIMEOUT_SECONDS` bounds `pgx.Connect`; individual DDL statements run under the Dapr activity context (bounded by the runtime's activity timeout, not a per-statement deadline).
 
 ## Architecture
 

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -167,6 +167,32 @@ SEC_URI=$(kubectl get secret "$E2E_RESOURCE_NAME" -n "$E2E_NAMESPACE" -o jsonpat
 [ "$SEC_URI" = "$URI" ] || fail "Secret uri mismatch (got '$SEC_URI')"
 echo "    Secret $E2E_RESOURCE_NAME carries the connection uri ✓"
 
+# --- Idempotent re-Put: reuse the existing binding, do not orphan ---
+echo "==> Re-Put with the existing binding (idempotent update)"
+REPUT=$(curl -s --fail-with-body -X PUT "${BASE_URL}/workflows" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"PostgresSQLDatabasesPut\",\"input\":{\"resource\":{\"name\":\"${E2E_RESOURCE_NAME}\",\"properties\":{\"status\":{\"binding\":{\"database\":\"${DB}\",\"username\":\"${USER}\"}}}},\"runtime\":{\"kubernetes\":{\"namespace\":\"${E2E_NAMESPACE}\"}}}}")
+RID2=$(jq -r '.id' <<<"$REPUT")
+[ -n "$RID2" ] && [ "$RID2" != null ] || fail "could not schedule re-Put; response: $REPUT"
+RFINAL=""
+deadline=$(( $(date +%s) + E2E_WORKFLOW_TIMEOUT_SECONDS ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  R=$(curl -s "${BASE_URL}/workflows/${RID2}")
+  case "$(jq -r '.runtimeStatus' <<<"$R")" in COMPLETED|FAILED|TERMINATED|CANCELED) RFINAL="$R"; break;; esac
+  sleep "$E2E_POLL_INTERVAL_SECONDS"
+done
+[ "$(jq -r '.runtimeStatus' <<<"$RFINAL")" = COMPLETED ] || fail "re-Put status=$(jq -r '.runtimeStatus' <<<"$RFINAL")"
+REDB=$(jq -r '.output|fromjson|.values.database' <<<"$RFINAL")
+REUSER=$(jq -r '.output|fromjson|.values.username' <<<"$RFINAL")
+{ [ "$REDB" = "$DB" ] && [ "$REUSER" = "$USER" ]; } || fail "re-Put did not reuse the binding (got $REUSER/$REDB, want $USER/$DB)"
+# Count only PROVISIONED databases (name is <resource>_<8 hex>), not the Dapr
+# state-store DBs sample_state / sample_metadata. Reuse ⇒ 1; a broken re-Put
+# that created a fresh database ⇒ 2.
+COUNT=$(docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
+  "SELECT count(*) FROM pg_database WHERE datname ~ '^${E2E_RESOURCE_NAME}_[0-9a-f]{8}\$'")
+[ "$COUNT" = "1" ] || fail "expected exactly 1 provisioned database after re-Put, got $COUNT (orphan leak)"
+echo "    re-Put reused $USER / $DB with no orphan (1 database) ✓"
+
 # --- Delete: tear the database down ---
 echo "==> Scheduling PostgresSQLDatabasesDelete"
 DEL=$(curl -s --fail-with-body -X PUT "${BASE_URL}/workflows" \

--- a/pkg/activities/activities_test.go
+++ b/pkg/activities/activities_test.go
@@ -171,6 +171,45 @@ func TestCreatePostgresDatabase(t *testing.T) {
 	}
 }
 
+func TestCreatePostgresUserReusesExistingRole(t *testing.T) {
+	fake := newFakePGAdmin()
+	withFakePGAdmin(t, fake)
+
+	out, err := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{Username: "pguser_keep"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.(CreatePostgresUserOutput)
+	if got.Username != "pguser_keep" {
+		t.Errorf("username = %q, want reused pguser_keep", got.Username)
+	}
+	if got.Password == "" {
+		t.Error("expected a rotated (freshly generated) password on reuse")
+	}
+	if fake.createdRoles["pguser_keep"] != got.Password {
+		t.Errorf("CreateRole not called with reused username + new password: %+v", fake.createdRoles)
+	}
+}
+
+func TestCreatePostgresDatabaseReusesExisting(t *testing.T) {
+	fake := newFakePGAdmin()
+	withFakePGAdmin(t, fake)
+
+	out, err := CreatePostgresDatabase(fakeActivityCtx{input: CreatePostgresDatabaseInput{
+		Username: "u", Password: "p", DatabasePrefix: "orders", Database: "orders_keep",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.(CreatePostgresDatabaseOutput)
+	if got.Database != "orders_keep" {
+		t.Errorf("database = %q, want reused orders_keep", got.Database)
+	}
+	if fake.createdDBs["orders_keep"] != "u" {
+		t.Errorf("CreateDatabase not called with reused database: %+v", fake.createdDBs)
+	}
+}
+
 func TestDeletePostgresUser(t *testing.T) {
 	fake := newFakePGAdmin()
 	withFakePGAdmin(t, fake)

--- a/pkg/activities/config.go
+++ b/pkg/activities/config.go
@@ -3,7 +3,15 @@ package activities
 import (
 	"os"
 	"strconv"
+	"time"
 )
+
+// opTimeout bounds an individual DDL statement (CREATE/DROP ROLE/DATABASE) so a
+// statement blocked on a lock cannot hang the activity indefinitely. Env-tunable
+// via PG_OP_TIMEOUT_SECONDS.
+func opTimeout() time.Duration {
+	return time.Duration(atoiOr(env("PG_OP_TIMEOUT_SECONDS", "30"), 30)) * time.Second
+}
 
 // postgresName is the literal "postgres" used, by PostgreSQL convention, as the
 // default superuser, the maintenance database, the connection URL scheme, and

--- a/pkg/activities/pgclient.go
+++ b/pkg/activities/pgclient.go
@@ -89,6 +89,9 @@ func (a *pgxAdmin) Close(ctx context.Context) error { return a.conn.Close(ctx) }
 // pgx.Identifier; the password literal is single-quote escaped (DDL cannot be
 // parameterized). CREATE ROLE errors if the role exists, so we check first.
 func (a *pgxAdmin) CreateRole(ctx context.Context, username, password string) error {
+	ctx, cancel := context.WithTimeout(ctx, opTimeout())
+	defer cancel()
+
 	var exists bool
 	if err := a.conn.QueryRow(ctx,
 		"SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", username,
@@ -116,6 +119,9 @@ func (a *pgxAdmin) CreateRole(ctx context.Context, username, password string) er
 
 // CreateDatabase creates the database owned by owner (idempotent).
 func (a *pgxAdmin) CreateDatabase(ctx context.Context, database, owner string) error {
+	ctx, cancel := context.WithTimeout(ctx, opTimeout())
+	defer cancel()
+
 	var exists bool
 	if err := a.conn.QueryRow(ctx,
 		"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", database,
@@ -143,7 +149,11 @@ func (a *pgxAdmin) DropDatabase(ctx context.Context, database string, backup boo
 	if backup {
 		a.backupDatabase(ctx, database)
 	}
-	_, err := a.conn.Exec(ctx, fmt.Sprintf(
+	// Bound only the DROP itself (the best-effort backup above may legitimately
+	// take longer than a single-statement timeout).
+	dctx, cancel := context.WithTimeout(ctx, opTimeout())
+	defer cancel()
+	_, err := a.conn.Exec(dctx, fmt.Sprintf(
 		"DROP DATABASE IF EXISTS %s WITH (FORCE)",
 		pgx.Identifier{database}.Sanitize()))
 	if err != nil {
@@ -154,6 +164,9 @@ func (a *pgxAdmin) DropDatabase(ctx context.Context, database string, backup boo
 
 // DropRole drops the role idempotently.
 func (a *pgxAdmin) DropRole(ctx context.Context, username string) error {
+	ctx, cancel := context.WithTimeout(ctx, opTimeout())
+	defer cancel()
+
 	_, err := a.conn.Exec(ctx, fmt.Sprintf(
 		"DROP ROLE IF EXISTS %s", pgx.Identifier{username}.Sanitize()))
 	if err != nil {

--- a/pkg/activities/postgres.go
+++ b/pkg/activities/postgres.go
@@ -27,6 +27,10 @@ func CallCreatePostgresUser(ctx *workflow.WorkflowContext, input CreatePostgresU
 }
 
 type CreatePostgresUserInput struct {
+	// Username, when non-empty, reuses an existing role (idempotent update): the
+	// role's password is rotated rather than a new role being created. Empty
+	// generates a fresh unique role name.
+	Username string `json:"username,omitempty"`
 }
 
 type CreatePostgresUserOutput struct {
@@ -34,15 +38,18 @@ type CreatePostgresUserOutput struct {
 	Password string `json:"password"`
 }
 
-// CreatePostgresUser provisions a unique LOGIN role on the admin PostgreSQL
-// endpoint with a freshly generated password.
+// CreatePostgresUser provisions (or, when Username is supplied, reuses) a LOGIN
+// role on the admin PostgreSQL endpoint with a freshly generated password.
 func CreatePostgresUser(ctx workflow.ActivityContext) (any, error) {
 	input := CreatePostgresUserInput{}
 	if err := ctx.GetInput(&input); err != nil {
 		return nil, err
 	}
 
-	username := "pguser_" + shortID()
+	username := input.Username
+	if username == "" {
+		username = "pguser_" + shortID()
+	}
 	password := uuid.NewString()
 
 	logger := slog.Default()
@@ -122,6 +129,10 @@ type CreatePostgresDatabaseInput struct {
 	Username       string `json:"username"`
 	Password       string `json:"password"`
 	DatabasePrefix string `json:"databasePrefix"`
+	// Database, when non-empty, reuses an existing database (idempotent update):
+	// CreateDatabase is a no-op if it already exists. Empty generates a fresh
+	// unique name from DatabasePrefix.
+	Database string `json:"database,omitempty"`
 }
 
 type CreatePostgresDatabaseOutput struct {
@@ -140,7 +151,10 @@ func CreatePostgresDatabase(ctx workflow.ActivityContext) (any, error) {
 		return nil, err
 	}
 
-	database := input.DatabasePrefix + "_" + shortID()
+	database := input.Database
+	if database == "" {
+		database = input.DatabasePrefix + "_" + shortID()
+	}
 
 	logger := slog.Default()
 	logger.Info("Creating database", slog.String("database", database), slog.String("owner", input.Username))

--- a/pkg/workflows/postgresqldatabases.go
+++ b/pkg/workflows/postgresqldatabases.go
@@ -23,18 +23,21 @@ func PostgresSQLDatabasesPut(ctx *workflow.WorkflowContext) (any, error) {
 		logger.Info("Creating/Updating PostgresSQL database")
 	}
 
-	// 1. Provision the login role, 2. create the database it owns (which returns
-	// the reachable host/port), then 3. publish the connection binding into
-	// Kubernetes. Ordering matters: the binding Secret carries the final
-	// credentials, so it is published last.
-	//
-	// NOTE (scaffold limitation): each Put provisions a FRESH role + database
-	// (unique random suffix) rather than reading and reusing a prior binding from
-	// request.Resource.Properties["status"]["binding"]. A real Radius recipe would
-	// reuse the existing binding on update; here a redeploy of the same resource
-	// creates new objects and leaves the old ones for PostgresSQLDatabasesDelete
-	// to reclaim. See CLAUDE.md "Known limitations".
-	credentials, err := activities.CallCreatePostgresUser(ctx, activities.CreatePostgresUserInput{})
+	// Idempotent update: if the recipe context carries a prior status.binding
+	// (the same shape PostgresSQLDatabasesDelete reads), reuse those role and
+	// database names — the role's password is rotated and the database ensured —
+	// instead of creating fresh objects and orphaning the old ones. On a first
+	// Put the bindings are empty, so fresh unique names are generated.
+	existingUser, _ := request.Resource.GetStringValue("/status/binding/username")
+	existingDatabase, _ := request.Resource.GetStringValue("/status/binding/database")
+
+	// 1. Provision (or reuse) the login role, 2. create (or ensure) the database
+	// it owns (which returns the reachable host/port), then 3. publish the
+	// connection binding into Kubernetes. Ordering matters: the binding Secret
+	// carries the final credentials, so it is published last.
+	credentials, err := activities.CallCreatePostgresUser(ctx, activities.CreatePostgresUserInput{
+		Username: existingUser,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -43,6 +46,7 @@ func PostgresSQLDatabasesPut(ctx *workflow.WorkflowContext) (any, error) {
 		Username:       credentials.Username,
 		Password:       credentials.Password,
 		DatabasePrefix: request.Resource.Name,
+		Database:       existingDatabase,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Resolves two of the scaffold limitations documented in #59.

- **`PostgresSQLDatabasesPut` is now update-idempotent** — it reads the prior `status.binding` (`username`/`database`) from the recipe context (the same shape `PostgresSQLDatabasesDelete` reads) and reuses those role/database names on redeploy: the role password is rotated, the database ensured. A first Put still generates fresh unique names. No more orphaned roles/databases on update.
- **Per-statement DDL timeouts** — each `CREATE`/`DROP ROLE`/`DATABASE` is bounded by `PG_OP_TIMEOUT_SECONDS` (default 30s) so a statement blocked on a lock can't hang the activity.

## Verification

- Unit tests cover the reuse paths (existing username → rotate password + reuse role; existing database → reuse).
- `make e2e` adds an **idempotent re-Put** step: after the first Put it re-Puts with the binding and asserts the **same** role+database are returned and **exactly one** provisioned database exists (a broken re-Put would leave two). Green end-to-end against real Postgres + kind.
- `make ci` green (coverage 44.5% > 40%), golangci-lint 0 issues, shellcheck clean.

## Test plan

- [x] `make ci` green
- [x] `make e2e` green (idempotent re-Put reuses binding, no orphan; teardown clean)
- [ ] CI `ci-pass` green
