### PR TITLE
feat: deploy a real PostgreSQL workload per recipe (Deployment + Service + Secret)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,9 @@ DAPR_RUNTIME_VERSION=1.18.0
 
 # --- e2e tunables ---
 E2E_READY_TIMEOUT_SECONDS=60
-E2E_WORKFLOW_TIMEOUT_SECONDS=90
+# Workflow terminal-state wait. The Put deploys a PostgreSQL workload (pod image
+# pull + rollout), so this is generous to survive a cold cluster / slow pull.
+E2E_WORKFLOW_TIMEOUT_SECONDS=180
 E2E_POLL_INTERVAL_SECONDS=2
 
 # --- PostgreSQL (local dev state store; see run-postgres.sh) ---
@@ -29,32 +31,28 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=daprrulz
 POSTGRES_DB=sample_state
 
-# --- Recipe backend: PostgreSQL admin endpoint (real provisioning) ---
-# The workflow activities connect here to run CREATE ROLE / CREATE DATABASE /
-# DROP ... . Each of these falls back to the POSTGRES_* value above when unset,
-# so a bare `make run` / `make e2e` provisions against the local dev container.
-# They are left commented so that fallback works — uncomment to point the recipe
-# at a DIFFERENT PostgreSQL than the dev state-store container.
-# PG_ADMIN_HOST=localhost
-# PG_ADMIN_PORT=5432
-# PG_ADMIN_USER=postgres
-# PG_ADMIN_PASSWORD=daprrulz
-# Maintenance database the admin connection targets (provisioned DBs live on the
-# same server). No POSTGRES_* fallback, so it is set here.
-PG_ADMIN_DB=postgres
-# sslmode for the admin connection (disable for the local dev container).
+# --- Recipe backend: deployed PostgreSQL workload ---
+# The workflow DEPLOYS a PostgreSQL workload (Deployment + Service + Secret) into
+# the cluster, waits for it to be ready, then runs provisioning DDL against it
+# via the deployed instance's superuser endpoint. The admin endpoint is derived
+# from the deployment (node-reachable NodePort), not from static env.
+#
+# PostgreSQL image the recipe deploys. Tracked by Renovate together with the Go
+# default in workloadImage() (custom.regex manager in renovate.json).
+# renovate: datasource=docker depName=postgres
+POSTGRES_WORKLOAD_IMAGE=postgres:18-alpine
+# How long DeployPostgres waits for the workload to become ready (seconds).
+PG_WORKLOAD_ROLLOUT_TIMEOUT_SECONDS=120
+# sslmode for the pgx admin connection to the deployed instance.
 PG_SSLMODE=disable
 # Admin connection dial timeout (seconds).
 PG_CONNECT_TIMEOUT_SECONDS=10
-# Per-statement timeout for a single DDL (CREATE/DROP ROLE/DATABASE), so a
+# Per-statement timeout for a single DDL (CREATE ROLE / CREATE DATABASE), so a
 # statement blocked on a lock cannot hang the workflow activity indefinitely.
 PG_OP_TIMEOUT_SECONDS=30
-# Directory for best-effort pg_dump backups on delete (used only if pg_dump is
-# on PATH). Defaults to the OS temp dir when unset.
-# PG_BACKUP_DIR=/tmp
 
 # --- Recipe backend: Kubernetes ---
-# The workflow publishes a Service + Secret binding via the Kubernetes API using
+# The workflow deploys the PostgreSQL workload via the Kubernetes API using
 # ambient kubeconfig (KUBECONFIG / ~/.kube/config), falling back to in-cluster
 # config when running inside a pod. Point KUBECONFIG at your target cluster.
 # KUBECONFIG=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,24 +8,26 @@ Go service that drives **Radius Recipes** via **Dapr durable workflows**. It exp
 
 **Owner:** AndriyKalashnykov/dapr-go-workflow-k8s
 
-> **The activities call real backends.** `pkg/activities/postgres.go` runs real DDL via **pgx/v5** against a PostgreSQL admin endpoint (`CREATE ROLE` / `CREATE DATABASE` / `DROP … WITH (FORCE)` / `DROP ROLE`), and `pkg/activities/kubernetes.go` publishes a real **Service + Secret** binding into the cluster via **client-go** (removed on delete). The returned recipe URI is genuinely connectable (built with `url.URL` escaping via `activities.ConnectionURI`). Backend clients are constructed through injectable package-level constructors (`newPGAdmin`, `newKubeBinder`) so activities are unit-tested hermetically against fakes; the real path is exercised by `make e2e`. The remaining extension point is swapping the Kubernetes binding for a full workload deploy (Deployment/StatefulSet) and wiring cloud-provider scopes (`recipes.ProviderAzure`/`ProviderAWS`).
+> **The activities deploy a real PostgreSQL workload.** `pkg/activities/kubernetes.go` uses **client-go** to deploy a dedicated PostgreSQL **Deployment + Service (NodePort) + Secret** per resource and waits for the rollout; `pkg/activities/postgres.go` then runs real DDL via **pgx/v5** (`CREATE ROLE` / `CREATE DATABASE`) on that deployed instance, reached from the host via the Service's node-IP:NodePort. The recipe advertises the in-cluster Service DNS (`<name>.<ns>.svc.cluster.local`) and a genuinely-connectable URI (`activities.ConnectionURI`, `url.URL`-escaped). Backend clients are built through injectable constructors (`newPGAdmin`, `newKubeDeployer`) so activities are unit-tested hermetically (fakes + client-go's fake clientset); the real path is exercised by `make e2e`. Delete destroys the workload (and with it the database/roles). The remaining extension point is wiring the cloud-provider scopes (`recipes.ProviderAzure`/`ProviderAWS`).
 
 ### Update idempotency & timeouts
 
-`PostgresSQLDatabasesPut` is **update-idempotent**: it reads the prior
-`status.binding` (`username`/`database`) from the recipe context — the same shape
-`PostgresSQLDatabasesDelete` reads — and reuses those role/database names on a
-redeploy (the role password is rotated, the database ensured) instead of creating
-fresh objects and orphaning the old ones. A first Put (empty binding) generates
-fresh unique names.
+`PostgresSQLDatabasesPut` is **update-idempotent**: the workload deploy reuses the
+existing Deployment/Service/Secret (an existing Secret's superuser password is
+kept, since a running pod's env can't change), and it reads the prior
+`status.binding` (`username`/`database`) from the recipe context to reuse those
+role/database names on the redeployed instance (the role password is rotated, the
+database ensured). A first Put (empty binding) generates fresh unique names.
 
 Individual DDL statements are bounded by `PG_OP_TIMEOUT_SECONDS` (default 30s) so a
-statement blocked on a lock cannot hang the activity; the admin dial is bounded
-separately by `PG_CONNECT_TIMEOUT_SECONDS`.
+statement blocked on a lock cannot hang the activity; the pgx dial is bounded by
+`PG_CONNECT_TIMEOUT_SECONDS`, and the workload rollout wait by
+`PG_WORKLOAD_ROLLOUT_TIMEOUT_SECONDS`.
 
 ### Known limitations (scaffold)
 
-- **Delete's backup is best-effort.** `DeletePostgresDatabase` runs `pg_dump` only if the binary is on `PATH`; a missing/failed backup is logged (`Warn`) and the `DROP DATABASE … WITH (FORCE)` proceeds regardless — the drop is the required side effect, the backup is advisory.
+- **Ephemeral storage.** The deployed Postgres has no PersistentVolume, so its data lives in the pod and is lost if the pod restarts — fine for the demo lifecycle, not for real durability.
+- **Host-reachability of the deployed instance is kind-specific.** Provisioning DDL reaches the workload via node-IP:NodePort, which is host-routable on kind (Linux/CI). A different cluster topology would need port-forward or in-cluster execution.
 
 ## Architecture
 
@@ -41,9 +43,9 @@ Request/response flow: client `PUT /workflows` → server schedules it on the wo
 
 ### Package layout & key patterns
 
-- `pkg/workflows/postgresqldatabases.go` — the two workflows (`PostgresSQLDatabasesPut`, `PostgresSQLDatabasesDelete`). They deserialize a `recipes.Context` from workflow input, call activities, and (for Put) assemble a `recipes.Result`. Put order: **create role → create database (returns the reachable host/port) → publish the K8s Service+Secret binding** (published last because the Secret carries the final credentials). Workflows must be **deterministic & replay-safe** — they branch on `ctx.IsReplaying()` only for logging; all side effects go through activities.
+- `pkg/workflows/postgresqldatabases.go` — the two workflows (`PostgresSQLDatabasesPut`, `PostgresSQLDatabasesDelete`). They deserialize a `recipes.Context` from workflow input, call activities, and (for Put) assemble a `recipes.Result`. Put order: **deploy the PostgreSQL workload (returns the reachable admin endpoint) → create role → create database** on it. Delete calls one activity that **destroys the workload**. Workflows must be **deterministic & replay-safe** — they branch on `ctx.IsReplaying()` only for logging; all side effects go through activities.
 - `pkg/activities/{kubernetes,postgres}.go` — each activity has **two functions**: a `Call*` helper (invoked from a workflow; wraps `ctx.CallActivity(...).Await(&out)` with typed in/out structs) and the registered activity itself (`func(ctx workflow.ActivityContext) (any, error)`). When adding an activity, follow this pair pattern AND register it in `main.go`'s `registerWorkflows`.
-- `pkg/activities/pgclient.go` / `kubeclient.go` — the real backend clients behind small interfaces (`pgAdmin`, `kubeBinder`), each constructed via a package-level `var new*` so tests inject fakes (`kubeclient_test.go` exercises the real binder against client-go's in-memory fake clientset). `pkg/activities/config.go` resolves the PostgreSQL admin endpoint from `PG_ADMIN_*` (falling back to `POSTGRES_*`).
+- `pkg/activities/pgclient.go` / `kubeclient.go` — the real backend clients behind small interfaces (`pgAdmin`, `kubeDeployer`), each constructed via a package-level `var new*` so tests inject fakes (`kubeclient_test.go` exercises the real `clientsetDeployer` against client-go's in-memory fake clientset). `pkg/activities/config.go` holds the env-tunables (`workloadImage`, timeouts). The pgx admin endpoint is threaded from the deploy (`activities.AdminConn`), not static env.
 - `pkg/recipes/` — the **Radius Recipe contract** types. `Context` mirrors a Radius recipe context (`Resource`, `Application`, `Environment`, `Runtime.Kubernetes`, plus `Azure`/`AWS` provider scopes); `Result` is the `{values, secrets, resources}` envelope Radius reads back. `Resource.GetStringValue` uses JSON-pointer lookups into `Properties`. `recipes/error.go` re-exports the `server` error types as aliases.
 - `pkg/server/error.go` — the structured error envelope (`{error:{code,message,...}}`) used by `mustWriteError`.
 
@@ -76,12 +78,12 @@ make postgres-stop
 
 `run-dapr.sh` points Dapr at `components/` (a `state.postgresql` statestore + a tracing `Configuration` wiring Zipkin at `localhost:9411`). All host/port values are env-driven (see `.env.example`), and `make` reads `.env` too (`-include .env`).
 
-Because the activities call real backends, running the workflow needs: a reachable **PostgreSQL admin endpoint** (`PG_ADMIN_*`, defaulting to the `POSTGRES_*` dev container) and a **kubeconfig** for a cluster (`KUBECONFIG` / `~/.kube/config`; `make e2e` provisions its own kind cluster). Fixed host ports are guarded before every bind by **`make check-ports`** (a prerequisite of `e2e`/`run`/`postgres-start`), which fails early naming the holder; override the matching `*_PORT` (or set it in `.env`) on a collision.
+Because the recipe deploys a real workload, running it needs a **kubeconfig** for a cluster (`KUBECONFIG` / `~/.kube/config`; `make e2e` provisions its own kind cluster) whose node IP is host-reachable (kind on Linux). The app still needs its own state-store PostgreSQL (`make postgres-start`) and a Dapr sidecar. Fixed host ports are guarded before every bind by **`make check-ports`** (a prerequisite of `e2e`/`run`/`postgres-start`), which fails early naming the holder; override the matching `*_PORT` (or set it in `.env`) on a collision.
 
 ## Testing notes
 
-- **Unit-tested**: `pkg/recipes` (100%), `pkg/activities` activity funcs (via a fake `ActivityContext`) + the real `kubeBinder` (via client-go's in-memory fake clientset in `kubeclient_test.go`), `pkg/server` (DTO, `Address`, handlers, `Start` lifecycle), `cmd/healthcheck`. `COVERAGE_THRESHOLD` defaults to **40%** because the pgx admin client, the workflow-orchestration funcs and their `Call*` wrappers are covered by `make e2e`, not unit tests.
-- **`make e2e`** is the real end-to-end test (`e2e/e2e-test.sh`): it `dapr init`s a control plane, starts PostgreSQL, **creates a kind cluster**, runs the app under a Dapr sidecar (with `KUBECONFIG` pointing at kind), schedules `PostgresSQLDatabasesPut`, and — beyond asserting the output shape — verifies the recipe **actually provisioned real backends**: the Postgres role + database exist and the returned URI authenticates, and a real Kubernetes Service + Secret were created. It then runs `PostgresSQLDatabasesDelete` and asserts the role, database, Service, and Secret are all gone. It manages (creates + deletes) its own kind cluster; `E2E_KIND_KEEP=1` keeps it. Runs in CI (the `e2e` job; kind + kubectl come from mise) and locally.
+- **Unit-tested**: `pkg/recipes` (100%), `pkg/activities` activity funcs (via a fake `ActivityContext`) + the real `clientsetDeployer` (object creation, idempotency, `waitAndDiscover`, delete — via client-go's in-memory fake clientset in `kubeclient_test.go`), `pkg/server`, `cmd/healthcheck`. `COVERAGE_THRESHOLD` defaults to **40%** because the pgx admin client, the deploy rollout, and the workflow-orchestration funcs are covered by `make e2e`, not unit tests.
+- **`make e2e`** is the real end-to-end test (`e2e/e2e-test.sh`): it `dapr init`s a control plane, starts the state-store PostgreSQL, **creates a kind cluster**, runs the app under a Dapr sidecar (`KUBECONFIG` → kind), schedules `PostgresSQLDatabasesPut`, and verifies the recipe **actually deployed a PostgreSQL workload**: the Deployment has a ready replica, and the provisioned role authenticates to its database **on the deployed instance** (via node-IP:NodePort). It then re-Puts (asserting idempotent reuse with no orphan) and runs `PostgresSQLDatabasesDelete`, asserting the Deployment/Service/Secret are gone. It manages its own kind cluster (`E2E_KIND_KEEP=1` keeps it). Runs in CI (the `e2e` job; kind + kubectl come from mise) and locally.
 - **Dapr runtime ≥ 1.18 is required** (`DAPR_RUNTIME_VERSION`, default 1.18.0). go-sdk v1.15 / durabletask-go v0.12 fail activity invocation on older runtimes with `required metadata dapr-callee-app-id ... not found`.
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/dapr-go-workflow-k8s)
 [![Go Reference](https://pkg.go.dev/badge/github.com/AndriyKalashnykov/dapr-go-workflow-k8s.svg)](https://pkg.go.dev/github.com/AndriyKalashnykov/dapr-go-workflow-k8s)
 
-Reference Go service that drives **[Radius](https://radapp.io/) Recipes** through **[Dapr](https://dapr.io/) durable workflows**. The **runtime surface** is a small REST API that schedules durable workflows (`durabletask-go` registry + `dapr/go-sdk`) which provision or tear down a **real** PostgreSQL database (via [`pgx`](https://github.com/jackc/pgx)) and a Kubernetes Service + Secret binding (via [`client-go`](https://github.com/kubernetes/client-go)), returning recipe outputs (`values`, `secrets`, `resources`) in the shape Radius expects; the **delivery surface** ships a distroless image, a real Dapr-sidecar + kind end-to-end test (`make e2e`) that verifies provisioning against a live Postgres and cluster, a `mise`-pinned toolchain, a `static-check` gate (golangci-lint, govulncheck, gitleaks, Trivy, hadolint, actionlint/shellcheck, mermaid-lint), and a GitHub Actions pipeline with a blocking Trivy scan and cosign keyless image signing, with Renovate-managed dependencies.
+Reference Go service that drives **[Radius](https://radapp.io/) Recipes** through **[Dapr](https://dapr.io/) durable workflows**. The **runtime surface** is a small REST API that schedules durable workflows (`durabletask-go` registry + `dapr/go-sdk`) which **deploy a real PostgreSQL workload** (Deployment + Service + Secret via [`client-go`](https://github.com/kubernetes/client-go)) and **provision a role + database on it** (via [`pgx`](https://github.com/jackc/pgx)), returning recipe outputs (`values`, `secrets`, `resources`) in the shape Radius expects; the **delivery surface** ships a distroless image, a real Dapr-sidecar + kind end-to-end test (`make e2e`) that deploys/provisions/tears down against a live cluster, a `mise`-pinned toolchain, a `static-check` gate (golangci-lint, govulncheck, gitleaks, Trivy, hadolint, actionlint/shellcheck, mermaid-lint), and a GitHub Actions pipeline with a blocking Trivy scan and cosign keyless image signing, with Renovate-managed dependencies.
 
-> **The activities call real backends.** The workflow runs real PostgreSQL DDL (`CREATE ROLE`/`CREATE DATABASE`/`DROP …`) via **pgx** and publishes a real Kubernetes **Service + Secret** binding via **client-go** — the returned recipe URI is genuinely connectable, and `make e2e` verifies the provisioning (and teardown) against a real Postgres and a real kind cluster. The remaining extension point is swapping the Kubernetes binding for a full workload deploy and wiring the Azure/AWS provider scopes.
+> **The activities deploy a real PostgreSQL workload.** `PostgresSQLDatabasesPut` uses **client-go** to deploy a dedicated PostgreSQL Deployment + Service + Secret per resource, waits for the rollout, then runs real DDL (`CREATE ROLE` / `CREATE DATABASE`) via **pgx** on the deployed instance (reached via the Service's node-IP:NodePort). The returned recipe URI is genuinely connectable; `PostgresSQLDatabasesDelete` destroys the workload. `make e2e` verifies the whole cycle against a real kind cluster. The remaining extension point is wiring the Azure/AWS provider scopes.
 
 | Component | Technology |
 |-----------|------------|
@@ -18,7 +18,8 @@ Reference Go service that drives **[Radius](https://radapp.io/) Recipes** throug
 | HTTP | `net/http` + [go-chi/chi](https://github.com/go-chi/chi) router |
 | Recipe contract | Radius Recipe `Context` / `Result` types (`pkg/recipes`) |
 | PostgreSQL backend | [`jackc/pgx`](https://github.com/jackc/pgx) v5 (real role/database provisioning) |
-| Kubernetes backend | [`k8s.io/client-go`](https://github.com/kubernetes/client-go) (real Service + Secret binding) |
+| Kubernetes backend | [`k8s.io/client-go`](https://github.com/kubernetes/client-go) (deploys the PostgreSQL Deployment + Service + Secret) |
+| Deployed workload | `postgres:18-alpine` (Renovate-tracked, env-tunable `POSTGRES_WORKLOAD_IMAGE`) |
 | State store | PostgreSQL (Dapr `state.postgresql` component) |
 | Container | `gcr.io/distroless/static-debian12:nonroot` (multi-stage build) |
 | CI / security | GitHub Actions, Trivy, gitleaks, govulncheck, cosign keyless signing |
@@ -31,7 +32,7 @@ make deps             # install toolchain + quality tools (via mise)
 make ci               # full local pipeline: format + static-check + test + coverage + build
 
 # Run the workflow end to end (needs Docker, the Dapr CLI, and a reachable
-# kubeconfig — the recipe publishes a real Service + Secret into the cluster):
+# kubeconfig — the recipe deploys a real PostgreSQL workload into the cluster):
 make postgres-start   # start a local PostgreSQL state store (the admin endpoint)
 make run              # run the app under a Dapr sidecar (uses KUBECONFIG / ~/.kube/config)
 ./start-workflow.sh   # health-check, PUT a workflow, poll until it completes
@@ -77,15 +78,16 @@ flowchart LR
   daprd["Dapr sidecar (daprd)"]
   ctrl["Placement + Scheduler"]
   pg[("PostgreSQL<br/>state store")]
-  pgadmin[("PostgreSQL<br/>role + database")]
-  k8s["Kubernetes API<br/>Service + Secret"]
+  k8s["Kubernetes API"]
+  pgwl[("Deployed PostgreSQL<br/>Deployment + Service")]
   client -->|"PUT /workflows"| http
   http -->|"schedule / fetch"| daprd
   daprd --> worker
   worker --> wf
   wf -->|"CallActivity"| act
-  act -->|"pgx DDL"| pgadmin
-  act -->|"client-go"| k8s
+  act -->|"client-go: deploy workload"| k8s
+  k8s -->|"schedules"| pgwl
+  act -->|"pgx DDL via NodePort"| pgwl
   daprd <--> ctrl
   daprd -->|"workflow / actor state"| pg
 ```
@@ -95,7 +97,7 @@ cmd/
   main.go          - Application entrypoint (worker + HTTP server)
   healthcheck/     - Dependency-free container HEALTHCHECK probe
 pkg/
-  activities/      - Dapr workflow activities: real Postgres DDL (pgx) + K8s Service/Secret binding (client-go)
+  activities/      - Dapr workflow activities: deploy a Postgres workload (client-go) + provision role/db on it (pgx)
   recipes/         - Radius Recipe contract types (Context / Result)
   server/          - HTTP server, routes, and the workflow-status DTO
   workflows/       - Durable workflow definitions (PostgreSQL databases put/delete)
@@ -114,8 +116,8 @@ All operator-tunable values are documented in [`.env.example`](.env.example). Co
 | `DAPR_GRPC_PORT` | `50001` | Dapr sidecar gRPC port |
 | `POSTGRES_PASSWORD` | `daprrulz` | Local dev PostgreSQL password |
 | `POSTGRES_PORT` | `5432` | Local dev PostgreSQL port |
-| `PG_ADMIN_*` | ← `POSTGRES_*` | Admin PostgreSQL endpoint the recipe provisions against (host/port/user/password); falls back to the `POSTGRES_*` dev container |
-| `KUBECONFIG` | `~/.kube/config` | Cluster the recipe publishes the Service + Secret binding into (`make e2e` uses its own kind cluster) |
+| `POSTGRES_WORKLOAD_IMAGE` | `postgres:18-alpine` | Image the recipe deploys as the database workload (Renovate-tracked) |
+| `KUBECONFIG` | `~/.kube/config` | Cluster the recipe deploys the PostgreSQL workload into (`make e2e` uses its own kind cluster) |
 
 Fixed host ports are guarded before every bind by `make check-ports` (a prerequisite of `e2e`/`run`/`postgres-start`); on a collision it fails early naming the holder, and you override the matching `*_PORT` (e.g. in `.env`).
 
@@ -143,7 +145,7 @@ Run `make help` to see all targets.
 | `make test` | Unit tests with race detector + coverage (seconds; `-short` skips the 5s backup sim) |
 | `make coverage-check` | Verify coverage meets `COVERAGE_THRESHOLD` (default 40%) |
 | `make e2e-deps` | Ensure the Dapr control plane (placement + scheduler) is up |
-| `make e2e` | End-to-end: real Dapr sidecar + real Postgres + a kind cluster; provisions a database, verifies the role/DB/URI + K8s Service/Secret, then tears it all down (minutes; needs Docker + Dapr CLI) |
+| `make e2e` | End-to-end: real Dapr sidecar + a kind cluster; deploys a PostgreSQL workload, verifies the role/DB on it + idempotent re-Put, then destroys the workload (minutes; needs Docker + Dapr CLI) |
 
 ### Code Quality
 
@@ -187,6 +189,6 @@ Run `make help` to see all targets.
 | `release.yml` | `v*.*.*` tags | reuses `ci.yml`, then GoReleaser publishes binaries + GitHub Release |
 | `cleanup-runs.yml` | weekly / dispatch | prunes old workflow runs and caches |
 
-The `e2e` job runs `make e2e`, which `dapr init`s a real control plane, starts PostgreSQL, creates a kind cluster, runs the app under a Dapr sidecar, and asserts the recipe **actually provisioned** a real Postgres role + database (the returned URI authenticates) and a real Kubernetes Service + Secret — then that `PostgresSQLDatabasesDelete` tears them all down (kind + kubectl come from mise). The `docker` job builds the image and runs a blocking Trivy scan on every push; on a tag it publishes a cosign-signed `linux/amd64` image to `ghcr.io/andriykalashnykov/dapr-go-workflow-k8s`. Branch protection requires the `ci-pass` check before merging (including for Renovate automerge).
+The `e2e` job runs `make e2e`, which `dapr init`s a real control plane, starts the state-store PostgreSQL, creates a kind cluster, runs the app under a Dapr sidecar, and asserts the recipe **actually deployed a PostgreSQL workload** (ready Deployment) and provisioned a role + database on it (the credentials authenticate over the Service's NodePort) — then re-Puts idempotently and `PostgresSQLDatabasesDelete` destroys the workload (kind + kubectl come from mise). The `docker` job builds the image and runs a blocking Trivy scan on every push; on a tag it publishes a cosign-signed `linux/amd64` image to `ghcr.io/andriykalashnykov/dapr-go-workflow-k8s`. Branch protection requires the `ci-pass` check before merging (including for Renovate automerge).
 
 > **Dapr runtime ≥ 1.18 is required.** go-sdk v1.15 / durabletask-go v0.12 fail activity invocation on older runtimes (`required metadata dapr-callee-app-id ... not found`). `make e2e` installs the version pinned by `DAPR_RUNTIME_VERSION` (default 1.18.0).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,14 +92,8 @@ func registerWorkflows(ctx context.Context, wfClient *workflow.Client) error {
 	if err := r.AddActivity(activities.CreatePostgresUser); err != nil {
 		return fmt.Errorf("error registering activity CreatePostgresUser: %w", err)
 	}
-	if err := r.AddActivity(activities.DeletePostgresUser); err != nil {
-		return fmt.Errorf("error registering activity DeletePostgresUser: %w", err)
-	}
 	if err := r.AddActivity(activities.CreatePostgresDatabase); err != nil {
 		return fmt.Errorf("error registering activity CreatePostgresDatabase: %w", err)
-	}
-	if err := r.AddActivity(activities.DeletePostgresDatabase); err != nil {
-		return fmt.Errorf("error registering activity DeletePostgresDatabase: %w", err)
 	}
 
 	if err := wfClient.StartWorker(ctx, r); err != nil {

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
-# End-to-end test of the REAL backends: runs the app under a real Dapr sidecar
-# against a real PostgreSQL and a real Kubernetes cluster (kind), schedules the
-# PostgresSQLDatabasesPut workflow, and asserts the recipe actually provisioned:
-#   * a real Postgres role + database (the returned URI authenticates), and
-#   * a real Kubernetes Service + Secret binding.
-# It then runs PostgresSQLDatabasesDelete and asserts everything is torn down.
+# End-to-end test of the workload-deploy recipe: runs the app under a real Dapr
+# sidecar, schedules PostgresSQLDatabasesPut, and asserts the recipe actually
+# DEPLOYED a PostgreSQL workload (Deployment + Service + Secret) into a real kind
+# cluster and provisioned a role + database on it (reachable via the Service's
+# NodePort). It then re-Puts (idempotent) and finally PostgresSQLDatabasesDelete,
+# asserting the workload is destroyed.
 #
 # Requires: dapr (initialized), docker, kubectl, kind, jq. The Makefile `e2e`
-# target wires up the Dapr control plane + PostgreSQL; this script manages the
-# kind cluster.
+# target wires up the Dapr control plane + the state-store PostgreSQL; this script
+# manages the kind cluster.
 set -uo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR/.." || exit 1
 
-# Committed defaults, then optional .env override.
 # shellcheck source=/dev/null
 if [ -f .env.example ]; then set -a; . ./.env.example; set +a; fi
 # shellcheck source=/dev/null
@@ -26,7 +25,7 @@ DAPR_APP_ID="${DAPR_APP_ID:-sample}"
 DAPR_GRPC_PORT="${DAPR_GRPC_PORT:-50001}"
 POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 E2E_READY_TIMEOUT_SECONDS="${E2E_READY_TIMEOUT_SECONDS:-60}"
-E2E_WORKFLOW_TIMEOUT_SECONDS="${E2E_WORKFLOW_TIMEOUT_SECONDS:-90}"
+E2E_WORKFLOW_TIMEOUT_SECONDS="${E2E_WORKFLOW_TIMEOUT_SECONDS:-150}"
 E2E_POLL_INTERVAL_SECONDS="${E2E_POLL_INTERVAL_SECONDS:-2}"
 E2E_READY_POLL_INTERVAL_SECONDS="${E2E_READY_POLL_INTERVAL_SECONDS:-1}"
 E2E_CURL_MAX_TIME_SECONDS="${E2E_CURL_MAX_TIME_SECONDS:-2}"
@@ -34,15 +33,9 @@ E2E_NAMESPACE="${E2E_NAMESPACE:-default}"
 E2E_RESOURCE_NAME="${E2E_RESOURCE_NAME:-sample}"
 E2E_KIND_CLUSTER="${E2E_KIND_CLUSTER:-dapr-go-workflow-k8s}"
 POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-sample-postgres}"
+POSTGRES_WORKLOAD_IMAGE="${POSTGRES_WORKLOAD_IMAGE:-postgres:18-alpine}"
+export POSTGRES_WORKLOAD_IMAGE
 BASE_URL="http://${APP_HOST}:${APP_PORT}"
-
-# The recipe activities provision against the PostgreSQL admin endpoint; default
-# it to the local dev container this e2e starts.
-export PG_ADMIN_HOST="${PG_ADMIN_HOST:-${POSTGRES_HOST:-localhost}}"
-export PG_ADMIN_PORT="${PG_ADMIN_PORT:-$POSTGRES_PORT}"
-export PG_ADMIN_USER="${PG_ADMIN_USER:-${POSTGRES_USER:-postgres}}"
-export PG_ADMIN_PASSWORD="${PG_ADMIN_PASSWORD:-${POSTGRES_PASSWORD:-daprrulz}}"
-export PG_ADMIN_DB="${PG_ADMIN_DB:-postgres}"
 
 LOG=$(mktemp -t dapr-e2e.XXXXXX.log)
 KCFG=$(mktemp -t dapr-e2e-kubeconfig.XXXXXX)
@@ -64,7 +57,14 @@ trap cleanup EXIT INT TERM
 
 fail() { echo "FAIL: $*"; [ -f "$LOG" ] && tail -40 "$LOG"; exit 1; }
 
-# --- Kubernetes: ensure a kind cluster and a dedicated kubeconfig ---
+# psql against the deployed instance via the node-reachable NodePort. --network
+# host makes the throwaway client see the kind node IP exactly as the host does.
+deployed_psql() { # $1=user $2=password $3=db $4=query
+  docker run --rm --network host -e PGPASSWORD="$2" "$POSTGRES_WORKLOAD_IMAGE" \
+    psql "postgresql://$1@${NODEIP}:${NODEPORT}/$3" -tAc "$4"
+}
+
+# --- Kubernetes: ensure a kind cluster + load the workload image ---
 echo "==> Ensuring kind cluster '$E2E_KIND_CLUSTER'"
 if kind get clusters 2>/dev/null | grep -qx "$E2E_KIND_CLUSTER"; then
   echo "    reusing existing cluster"
@@ -75,12 +75,14 @@ fi
 kind get kubeconfig --name "$E2E_KIND_CLUSTER" >"$KCFG" 2>/dev/null || fail "kind get kubeconfig"
 kubectl --request-timeout=10s get ns "$E2E_NAMESPACE" >/dev/null 2>&1 || fail "namespace $E2E_NAMESPACE not reachable"
 
-# --- Dapr components: render statestore with the effective POSTGRES_PORT ---
-# Dapr component metadata has no {env:} substitution, so render at runtime.
+# The deployed pod pulls $POSTGRES_WORKLOAD_IMAGE from its registry; the rollout
+# wait (PG_WORKLOAD_ROLLOUT_TIMEOUT_SECONDS) accommodates the pull time.
+
+# --- Dapr state-store components: render statestore with the effective port ---
 sed "s/port=5432/port=${POSTGRES_PORT}/" components/statestore.yaml >"$COMP/statestore.yaml"
 cp components/config.yaml "$COMP/config.yaml"
 
-echo "==> Launching app under Dapr sidecar (app-id=$DAPR_APP_ID, port=$APP_PORT, kube-ctx=$(kubectl config current-context))"
+echo "==> Launching app under Dapr sidecar (app-id=$DAPR_APP_ID, kube-ctx=$(kubectl config current-context))"
 dapr run --app-id "$DAPR_APP_ID" --app-port "$APP_PORT" \
   --resources-path "$COMP" --config "$COMP/config.yaml" \
   --dapr-grpc-port "$DAPR_GRPC_PORT" -- ./cmd/main >"$LOG" 2>&1 &
@@ -95,8 +97,8 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 done
 [ -n "$ready" ] || fail "app did not become healthy within ${E2E_READY_TIMEOUT_SECONDS}s"
 
-# --- Put: provision the database ---
-echo "==> Scheduling PostgresSQLDatabasesPut"
+# --- Put: deploy the workload + provision ---
+echo "==> Scheduling PostgresSQLDatabasesPut (deploys a PostgreSQL workload)"
 PUT=$(curl -s --fail-with-body -X PUT "${BASE_URL}/workflows" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"PostgresSQLDatabasesPut\",\"input\":{\"resource\":{\"name\":\"${E2E_RESOURCE_NAME}\"},\"runtime\":{\"kubernetes\":{\"namespace\":\"${E2E_NAMESPACE}\"}}}}")
@@ -115,60 +117,49 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep "$E2E_POLL_INTERVAL_SECONDS"
 done
 [ -n "$FINAL" ] || fail "workflow did not reach a terminal state within ${E2E_WORKFLOW_TIMEOUT_SECONDS}s"
-STATUS=$(jq -r '.runtimeStatus' <<<"$FINAL")
-if [ "$STATUS" != COMPLETED ]; then
-  echo "FAIL: workflow ended as $STATUS (expected COMPLETED); failureReason:"
-  jq -r '.failureReason // "(none)"' <<<"$FINAL"
-  tail -40 "$LOG" || true
-  exit 1
+if [ "$(jq -r '.runtimeStatus' <<<"$FINAL")" != COMPLETED ]; then
+  echo "FAIL: workflow ended as $(jq -r '.runtimeStatus' <<<"$FINAL"); failureReason:"
+  jq -r '.failureReason // "(none)"' <<<"$FINAL"; tail -40 "$LOG" || true; exit 1
 fi
 
 # Assert the recipe output shape.
-if ! jq -e --arg port "$POSTGRES_PORT" --arg name "$E2E_RESOURCE_NAME" '
+if ! jq -e --arg name "$E2E_RESOURCE_NAME" '
   (.output | fromjson) as $o
   | (($o.values.username // "") | startswith("pguser_"))
-  and ($o.values.port == $port)
+  and ($o.values.port == "5432")
+  and (($o.values.host // "") | endswith(".svc.cluster.local"))
   and (($o.values.database // "") | startswith($name + "_"))
   and (($o.secrets.password // "") | length > 0)
   and (($o.secrets.uri // "") | startswith("postgresql://"))
-  and (($o.resources | length) == 2)
+  and (($o.resources | length) == 3)
 ' <<<"$FINAL" >/dev/null; then
-  echo "FAIL: workflow output did not match the expected recipe shape"
-  jq '.output | fromjson' <<<"$FINAL"
-  exit 1
+  echo "FAIL: workflow output did not match the expected recipe shape"; jq '.output | fromjson' <<<"$FINAL"; exit 1
 fi
-echo "==> Recipe output shape OK"
-jq '.output | fromjson' <<<"$FINAL"
+echo "==> Recipe output shape OK"; jq '.output | fromjson' <<<"$FINAL"
 
 DB=$(jq -r '.output|fromjson|.values.database' <<<"$FINAL")
 USER=$(jq -r '.output|fromjson|.values.username' <<<"$FINAL")
 PASS=$(jq -r '.output|fromjson|.secrets.password' <<<"$FINAL")
-URI=$(jq -r '.output|fromjson|.secrets.uri' <<<"$FINAL")
 
-echo "==> Verifying REAL PostgreSQL provisioning"
-docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
-  "SELECT 1 FROM pg_roles WHERE rolname='$USER'" | grep -q 1 || fail "role $USER not found in postgres"
-echo "    role $USER exists ✓"
-docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
-  "SELECT 1 FROM pg_database WHERE datname='$DB'" | grep -q 1 || fail "database $DB not found in postgres"
-echo "    database $DB exists ✓"
-# The returned credentials must authenticate as the provisioned user into the
-# provisioned db. Reconnect from inside the container (localhost:5432 there is
-# the same server the URI advertises) using the exact returned user/password/db.
-CURI="postgresql://${USER}:${PASS}@localhost:5432/${DB}"
-docker exec "$POSTGRES_CONTAINER" psql "$CURI" -tAc "SELECT current_database()||'/'||current_user" \
-  | grep -qx "$DB/$USER" || fail "returned credentials did not authenticate to $DB as $USER"
-echo "    returned credentials authenticate ✓"
+echo "==> Verifying the REAL PostgreSQL workload in ns/$E2E_NAMESPACE"
+kubectl -n "$E2E_NAMESPACE" get deployment "$E2E_RESOURCE_NAME" >/dev/null 2>&1 || fail "Deployment not created"
+[ "$(kubectl -n "$E2E_NAMESPACE" get deployment "$E2E_RESOURCE_NAME" -o jsonpath='{.status.readyReplicas}')" = "1" ] || fail "Deployment not ready"
+echo "    Deployment $E2E_RESOURCE_NAME has a ready replica ✓"
+kubectl -n "$E2E_NAMESPACE" get service "$E2E_RESOURCE_NAME" >/dev/null 2>&1 || fail "Service not created"
+kubectl -n "$E2E_NAMESPACE" get secret "$E2E_RESOURCE_NAME" >/dev/null 2>&1 || fail "Secret not created"
+echo "    Service + Secret exist ✓"
 
-echo "==> Verifying REAL Kubernetes binding in ns/$E2E_NAMESPACE"
-kubectl get service "$E2E_RESOURCE_NAME" -n "$E2E_NAMESPACE" >/dev/null 2>&1 || fail "Service not created"
-echo "    Service $E2E_RESOURCE_NAME exists ✓"
-SEC_URI=$(kubectl get secret "$E2E_RESOURCE_NAME" -n "$E2E_NAMESPACE" -o jsonpath='{.data.uri}' 2>/dev/null | base64 -d)
-[ "$SEC_URI" = "$URI" ] || fail "Secret uri mismatch (got '$SEC_URI')"
-echo "    Secret $E2E_RESOURCE_NAME carries the connection uri ✓"
+# Discover the node-reachable endpoint and verify the provisioned role + database.
+NODEIP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+NODEPORT=$(kubectl -n "$E2E_NAMESPACE" get svc "$E2E_RESOURCE_NAME" -o jsonpath='{.spec.ports[0].nodePort}')
+[ -n "$NODEIP" ] && [ -n "$NODEPORT" ] || fail "could not discover node endpoint"
+echo "==> Verifying the provisioned role + database on the deployed instance ($NODEIP:$NODEPORT)"
+deployed_psql "$USER" "$PASS" "$DB" "SELECT current_database()||'/'||current_user" | grep -qx "$DB/$USER" \
+  || fail "the returned credentials did not authenticate to $DB as $USER on the deployed instance"
+echo "    role $USER authenticates to database $DB on the deployed workload ✓"
 
-# --- Idempotent re-Put: reuse the existing binding, do not orphan ---
-echo "==> Re-Put with the existing binding (idempotent update)"
+# --- Idempotent re-Put ---
+echo "==> Re-Put with the existing binding (idempotent update, reuses the instance)"
 REPUT=$(curl -s --fail-with-body -X PUT "${BASE_URL}/workflows" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"PostgresSQLDatabasesPut\",\"input\":{\"resource\":{\"name\":\"${E2E_RESOURCE_NAME}\",\"properties\":{\"status\":{\"binding\":{\"database\":\"${DB}\",\"username\":\"${USER}\"}}}},\"runtime\":{\"kubernetes\":{\"namespace\":\"${E2E_NAMESPACE}\"}}}}")
@@ -185,23 +176,18 @@ done
 REDB=$(jq -r '.output|fromjson|.values.database' <<<"$RFINAL")
 REUSER=$(jq -r '.output|fromjson|.values.username' <<<"$RFINAL")
 { [ "$REDB" = "$DB" ] && [ "$REUSER" = "$USER" ]; } || fail "re-Put did not reuse the binding (got $REUSER/$REDB, want $USER/$DB)"
-# Count only PROVISIONED databases (name is <resource>_<8 hex>), not the Dapr
-# state-store DBs sample_state / sample_metadata. Reuse ⇒ 1; a broken re-Put
-# that created a fresh database ⇒ 2.
-COUNT=$(docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
-  "SELECT count(*) FROM pg_database WHERE datname ~ '^${E2E_RESOURCE_NAME}_[0-9a-f]{8}\$'")
+SUPERPW=$(kubectl -n "$E2E_NAMESPACE" get secret "$E2E_RESOURCE_NAME" -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
+COUNT=$(deployed_psql postgres "$SUPERPW" postgres "SELECT count(*) FROM pg_database WHERE datname ~ '^${E2E_RESOURCE_NAME}_[0-9a-f]{8}\$'")
 [ "$COUNT" = "1" ] || fail "expected exactly 1 provisioned database after re-Put, got $COUNT (orphan leak)"
-echo "    re-Put reused $USER / $DB with no orphan (1 database) ✓"
+echo "    re-Put reused $USER / $DB with no orphan (1 database on the instance) ✓"
 
-# --- Delete: tear the database down ---
-echo "==> Scheduling PostgresSQLDatabasesDelete"
+# --- Delete: destroy the workload ---
+echo "==> Scheduling PostgresSQLDatabasesDelete (destroys the workload)"
 DEL=$(curl -s --fail-with-body -X PUT "${BASE_URL}/workflows" \
   -H 'Content-Type: application/json' \
-  -d "{\"name\":\"PostgresSQLDatabasesDelete\",\"input\":{\"resource\":{\"name\":\"${E2E_RESOURCE_NAME}\",\"properties\":{\"status\":{\"binding\":{\"database\":\"${DB}\",\"username\":\"${USER}\"}}}},\"runtime\":{\"kubernetes\":{\"namespace\":\"${E2E_NAMESPACE}\"}}}}")
+  -d "{\"name\":\"PostgresSQLDatabasesDelete\",\"input\":{\"resource\":{\"name\":\"${E2E_RESOURCE_NAME}\"},\"runtime\":{\"kubernetes\":{\"namespace\":\"${E2E_NAMESPACE}\"}}}}")
 DID=$(jq -r '.id' <<<"$DEL")
 [ -n "$DID" ] && [ "$DID" != null ] || fail "could not schedule delete; response: $DEL"
-echo "    instance id: $DID"
-
 DFINAL=""
 deadline=$(( $(date +%s) + E2E_WORKFLOW_TIMEOUT_SECONDS ))
 while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -212,12 +198,9 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 done
 [ "$DFINAL" = COMPLETED ] || fail "delete workflow ended as ${DFINAL:-<timeout>} (expected COMPLETED)"
 
-echo "==> Verifying teardown"
-docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
-  "SELECT 1 FROM pg_database WHERE datname='$DB'" | grep -q 1 && fail "database $DB still present" || echo "    database dropped ✓"
-docker exec "$POSTGRES_CONTAINER" psql -U "$PG_ADMIN_USER" -tAc \
-  "SELECT 1 FROM pg_roles WHERE rolname='$USER'" | grep -q 1 && fail "role $USER still present" || echo "    role dropped ✓"
-kubectl get service "$E2E_RESOURCE_NAME" -n "$E2E_NAMESPACE" >/dev/null 2>&1 && fail "Service still present" || echo "    Service deleted ✓"
-kubectl get secret "$E2E_RESOURCE_NAME" -n "$E2E_NAMESPACE" >/dev/null 2>&1 && fail "Secret still present" || echo "    Secret deleted ✓"
+echo "==> Verifying the workload was destroyed"
+kubectl -n "$E2E_NAMESPACE" get deployment "$E2E_RESOURCE_NAME" >/dev/null 2>&1 && fail "Deployment still present" || echo "    Deployment deleted ✓"
+kubectl -n "$E2E_NAMESPACE" get service "$E2E_RESOURCE_NAME" >/dev/null 2>&1 && fail "Service still present" || echo "    Service deleted ✓"
+kubectl -n "$E2E_NAMESPACE" get secret "$E2E_RESOURCE_NAME" >/dev/null 2>&1 && fail "Secret still present" || echo "    Secret deleted ✓"
 
-echo "==> E2E PASSED — real Postgres + real Kubernetes provisioning and teardown verified end-to-end"
+echo "==> E2E PASSED — real PostgreSQL workload deployed, provisioned, reused, and destroyed"

--- a/pkg/activities/activities_test.go
+++ b/pkg/activities/activities_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/dapr/durabletask-go/workflow"
 )
 
-// fakeActivityCtx implements workflow.ActivityContext (task.ActivityContext) for
-// unit-testing activity functions in isolation. GetInput JSON-round-trips the
-// supplied input, matching how the real runtime serializes activity inputs.
+// fakeActivityCtx implements workflow.ActivityContext for unit-testing activity
+// functions in isolation. GetInput JSON-round-trips the supplied input, matching
+// how the real runtime serializes activity inputs.
 type fakeActivityCtx struct {
 	input any
 }
@@ -40,9 +40,7 @@ var _ workflow.ActivityContext = fakeActivityCtx{}
 type fakePGAdmin struct {
 	createdRoles map[string]string // username -> password
 	createdDBs   map[string]string // database -> owner
-	droppedDBs   []string
-	droppedRoles []string
-	backups      []string
+	gotEndpoint  PGEndpoint
 	closed       bool
 }
 
@@ -58,53 +56,46 @@ func (f *fakePGAdmin) CreateDatabase(_ context.Context, database, owner string) 
 	f.createdDBs[database] = owner
 	return nil
 }
-func (f *fakePGAdmin) DropDatabase(_ context.Context, database string, backup bool) error {
-	if backup {
-		f.backups = append(f.backups, database)
-	}
-	f.droppedDBs = append(f.droppedDBs, database)
-	return nil
-}
-func (f *fakePGAdmin) DropRole(_ context.Context, username string) error {
-	f.droppedRoles = append(f.droppedRoles, username)
-	return nil
-}
 func (f *fakePGAdmin) Close(context.Context) error { f.closed = true; return nil }
 
-// withFakePGAdmin swaps newPGAdmin for the test and restores it afterwards.
 func withFakePGAdmin(t *testing.T, fake *fakePGAdmin) {
 	t.Helper()
 	prev := newPGAdmin
-	newPGAdmin = func(context.Context) (pgAdmin, error) { return fake, nil }
+	newPGAdmin = func(_ context.Context, ep PGEndpoint) (pgAdmin, error) {
+		fake.gotEndpoint = ep
+		return fake, nil
+	}
 	t.Cleanup(func() { newPGAdmin = prev })
 }
 
-type fakeKubeBinder struct {
-	ensured map[string]BindingConnection // "ns/name" -> conn
-	deleted []string
+type fakeKubeDeployer struct {
+	deployed map[string]bool // "ns/name" -> true
+	deleted  []string
+	ret      PostgresDeployment
 }
 
-func newFakeKubeBinder() *fakeKubeBinder {
-	return &fakeKubeBinder{ensured: map[string]BindingConnection{}}
+func newFakeKubeDeployer(ret PostgresDeployment) *fakeKubeDeployer {
+	return &fakeKubeDeployer{deployed: map[string]bool{}, ret: ret}
 }
 
-func (f *fakeKubeBinder) EnsureBinding(_ context.Context, namespace, name string, conn BindingConnection) ([]string, error) {
-	f.ensured[namespace+"/"+name] = conn
-	return []string{
-		resourceID(namespace, "Service", name),
-		resourceID(namespace, "Secret", name),
-	}, nil
+func (f *fakeKubeDeployer) DeployPostgres(_ context.Context, namespace, name string) (PostgresDeployment, error) {
+	f.deployed[namespace+"/"+name] = true
+	return f.ret, nil
 }
-func (f *fakeKubeBinder) DeleteBinding(_ context.Context, namespace, name string) error {
+func (f *fakeKubeDeployer) DeletePostgres(_ context.Context, namespace, name string) error {
 	f.deleted = append(f.deleted, namespace+"/"+name)
 	return nil
 }
 
-func withFakeKubeBinder(t *testing.T, fake *fakeKubeBinder) {
+func withFakeKubeDeployer(t *testing.T, fake *fakeKubeDeployer) {
 	t.Helper()
-	prev := newKubeBinder
-	newKubeBinder = func(context.Context) (kubeBinder, error) { return fake, nil }
-	t.Cleanup(func() { newKubeBinder = prev })
+	prev := newKubeDeployer
+	newKubeDeployer = func(context.Context) (kubeDeployer, error) { return fake, nil }
+	t.Cleanup(func() { newKubeDeployer = prev })
+}
+
+func testAdminConn() AdminConn {
+	return AdminConn{AdminHost: "172.18.0.4", AdminPort: "32187", AdminUser: "postgres", AdminPassword: "superpw"}
 }
 
 // --- Postgres activities ---
@@ -113,7 +104,7 @@ func TestCreatePostgresUser(t *testing.T) {
 	fake := newFakePGAdmin()
 	withFakePGAdmin(t, fake)
 
-	out, err := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{}})
+	out, err := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{AdminConn: testAdminConn()}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -122,13 +113,33 @@ func TestCreatePostgresUser(t *testing.T) {
 		t.Errorf("username = %q, want prefix pguser_", got.Username)
 	}
 	if got.Password == "" {
-		t.Error("expected a generated password, got empty")
+		t.Error("expected a generated password")
 	}
 	if fake.createdRoles[got.Username] != got.Password {
 		t.Errorf("CreateRole not called with returned credentials: %+v", fake.createdRoles)
 	}
+	if fake.gotEndpoint.Host != "172.18.0.4" || fake.gotEndpoint.Port != "32187" || fake.gotEndpoint.User != "postgres" {
+		t.Errorf("admin endpoint not threaded from input: %+v", fake.gotEndpoint)
+	}
 	if !fake.closed {
 		t.Error("expected admin connection to be closed")
+	}
+}
+
+func TestCreatePostgresUserReusesExistingRole(t *testing.T) {
+	fake := newFakePGAdmin()
+	withFakePGAdmin(t, fake)
+
+	out, err := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{AdminConn: testAdminConn(), Username: "pguser_keep"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.(CreatePostgresUserOutput)
+	if got.Username != "pguser_keep" {
+		t.Errorf("username = %q, want reused pguser_keep", got.Username)
+	}
+	if got.Password == "" || fake.createdRoles["pguser_keep"] != got.Password {
+		t.Errorf("expected reused username + rotated password: %+v", fake.createdRoles)
 	}
 }
 
@@ -136,14 +147,11 @@ func TestCreatePostgresUserCredentialsAreUnique(t *testing.T) {
 	fake := newFakePGAdmin()
 	withFakePGAdmin(t, fake)
 
-	a, _ := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{}})
-	b, _ := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{}})
+	a, _ := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{AdminConn: testAdminConn()}})
+	b, _ := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{AdminConn: testAdminConn()}})
 	ao, bo := a.(CreatePostgresUserOutput), b.(CreatePostgresUserOutput)
-	if ao.Username == bo.Username {
-		t.Error("expected distinct usernames across invocations")
-	}
-	if ao.Password == bo.Password {
-		t.Error("expected distinct passwords across invocations")
+	if ao.Username == bo.Username || ao.Password == bo.Password {
+		t.Error("expected distinct usernames and passwords across invocations")
 	}
 }
 
@@ -152,9 +160,7 @@ func TestCreatePostgresDatabase(t *testing.T) {
 	withFakePGAdmin(t, fake)
 
 	out, err := CreatePostgresDatabase(fakeActivityCtx{input: CreatePostgresDatabaseInput{
-		Username:       "u",
-		Password:       "p",
-		DatabasePrefix: "orders",
+		AdminConn: testAdminConn(), Username: "u", DatabasePrefix: "orders",
 	}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -163,31 +169,8 @@ func TestCreatePostgresDatabase(t *testing.T) {
 	if !strings.HasPrefix(got.Database, "orders_") {
 		t.Errorf("database = %q, want prefix orders_", got.Database)
 	}
-	if got.Host == "" || got.Port == "" {
-		t.Errorf("expected host/port, got host=%q port=%q", got.Host, got.Port)
-	}
 	if fake.createdDBs[got.Database] != "u" {
 		t.Errorf("CreateDatabase not called with owner u: %+v", fake.createdDBs)
-	}
-}
-
-func TestCreatePostgresUserReusesExistingRole(t *testing.T) {
-	fake := newFakePGAdmin()
-	withFakePGAdmin(t, fake)
-
-	out, err := CreatePostgresUser(fakeActivityCtx{input: CreatePostgresUserInput{Username: "pguser_keep"}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got := out.(CreatePostgresUserOutput)
-	if got.Username != "pguser_keep" {
-		t.Errorf("username = %q, want reused pguser_keep", got.Username)
-	}
-	if got.Password == "" {
-		t.Error("expected a rotated (freshly generated) password on reuse")
-	}
-	if fake.createdRoles["pguser_keep"] != got.Password {
-		t.Errorf("CreateRole not called with reused username + new password: %+v", fake.createdRoles)
 	}
 }
 
@@ -196,132 +179,88 @@ func TestCreatePostgresDatabaseReusesExisting(t *testing.T) {
 	withFakePGAdmin(t, fake)
 
 	out, err := CreatePostgresDatabase(fakeActivityCtx{input: CreatePostgresDatabaseInput{
-		Username: "u", Password: "p", DatabasePrefix: "orders", Database: "orders_keep",
+		AdminConn: testAdminConn(), Username: "u", DatabasePrefix: "orders", Database: "orders_keep",
 	}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := out.(CreatePostgresDatabaseOutput)
-	if got.Database != "orders_keep" {
-		t.Errorf("database = %q, want reused orders_keep", got.Database)
-	}
-	if fake.createdDBs["orders_keep"] != "u" {
-		t.Errorf("CreateDatabase not called with reused database: %+v", fake.createdDBs)
-	}
-}
-
-func TestDeletePostgresUser(t *testing.T) {
-	fake := newFakePGAdmin()
-	withFakePGAdmin(t, fake)
-
-	out, err := DeletePostgresUser(fakeActivityCtx{input: DeletePostgresUserInput{Username: "u"}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, ok := out.(DeletePostgresUserOutput); !ok {
-		t.Errorf("unexpected output type %T", out)
-	}
-	if len(fake.droppedRoles) != 1 || fake.droppedRoles[0] != "u" {
-		t.Errorf("expected DropRole(u), got %+v", fake.droppedRoles)
-	}
-}
-
-func TestDeletePostgresDatabase(t *testing.T) {
-	fake := newFakePGAdmin()
-	withFakePGAdmin(t, fake)
-
-	out, err := DeletePostgresDatabase(fakeActivityCtx{input: DeletePostgresDatabaseInput{
-		Database:     "orders_x",
-		CreateBackup: true,
-	}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, ok := out.(DeletePostgresDatabaseOutput); !ok {
-		t.Errorf("unexpected output type %T", out)
-	}
-	if len(fake.droppedDBs) != 1 || fake.droppedDBs[0] != "orders_x" {
-		t.Errorf("expected DropDatabase(orders_x), got %+v", fake.droppedDBs)
-	}
-	if len(fake.backups) != 1 {
-		t.Errorf("expected a backup to be requested, got %+v", fake.backups)
-	}
-}
-
-func TestDeletePostgresDatabaseNoBackup(t *testing.T) {
-	fake := newFakePGAdmin()
-	withFakePGAdmin(t, fake)
-
-	_, err := DeletePostgresDatabase(fakeActivityCtx{input: DeletePostgresDatabaseInput{
-		Database:     "orders_x",
-		CreateBackup: false,
-	}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(fake.backups) != 0 {
-		t.Errorf("expected no backup, got %+v", fake.backups)
+	if got.Database != "orders_keep" || fake.createdDBs["orders_keep"] != "u" {
+		t.Errorf("expected reused database orders_keep owned by u: got %q, %+v", got.Database, fake.createdDBs)
 	}
 }
 
 // --- Kubernetes activities ---
 
 func TestDeployKubernetesResources(t *testing.T) {
-	fake := newFakeKubeBinder()
-	withFakeKubeBinder(t, fake)
+	ret := PostgresDeployment{
+		Resources:     []string{"a", "b", "c"},
+		InClusterHost: "sample.default.svc.cluster.local",
+		Port:          "5432",
+		AdminUser:     "postgres",
+		AdminPassword: "pw",
+		ReachableHost: "172.18.0.4",
+		ReachablePort: "32187",
+	}
+	fake := newFakeKubeDeployer(ret)
+	withFakeKubeDeployer(t, fake)
 
 	out, err := DeployKubernetesResources(fakeActivityCtx{input: DeployKubernetesResourcesInput{
-		Namespace: "team-a",
-		Name:      "db1",
-		Host:      "localhost",
-		Port:      "5432",
-		Username:  "u",
-		Password:  "p",
-		Database:  "db1_abc",
-		URI:       "postgresql://u:p@localhost:5432/db1_abc",
+		Namespace: "default", Name: "sample",
 	}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	got := out.(DeployKubernetesResourcesOutput)
-	if len(got.Resources) != 2 {
-		t.Errorf("expected 2 resources, got %d: %v", len(got.Resources), got.Resources)
+	got := out.(PostgresDeployment)
+	if len(got.Resources) != 3 || got.InClusterHost != ret.InClusterHost ||
+		got.ReachableHost != "172.18.0.4" || got.ReachablePort != "32187" || got.AdminPassword != "pw" {
+		t.Errorf("deploy output not threaded through: %+v", got)
 	}
-	conn, ok := fake.ensured["team-a/db1"]
-	if !ok {
-		t.Fatalf("EnsureBinding not called for team-a/db1: %+v", fake.ensured)
-	}
-	if conn.URI != "postgresql://u:p@localhost:5432/db1_abc" || conn.Database != "db1_abc" {
-		t.Errorf("binding connection not threaded through: %+v", conn)
+	if !fake.deployed["default/sample"] {
+		t.Errorf("DeployPostgres not called for default/sample: %+v", fake.deployed)
 	}
 }
 
 func TestDeleteKubernetesResources(t *testing.T) {
-	fake := newFakeKubeBinder()
-	withFakeKubeBinder(t, fake)
+	fake := newFakeKubeDeployer(PostgresDeployment{})
+	withFakeKubeDeployer(t, fake)
 
-	out, err := DeleteKubernetesResources(fakeActivityCtx{input: DeleteKubernetesResourcesInput{
-		Namespace: "team-a",
-		Name:      "db1",
+	_, err := DeleteKubernetesResources(fakeActivityCtx{input: DeleteKubernetesResourcesInput{
+		Namespace: "default", Name: "sample",
 	}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, ok := out.(DeleteKubernetesResourcesOutput); !ok {
-		t.Errorf("unexpected output type %T", out)
-	}
-	if len(fake.deleted) != 1 || fake.deleted[0] != "team-a/db1" {
-		t.Errorf("expected DeleteBinding(team-a/db1), got %+v", fake.deleted)
+	if len(fake.deleted) != 1 || fake.deleted[0] != "default/sample" {
+		t.Errorf("expected DeletePostgres(default/sample), got %+v", fake.deleted)
 	}
 }
 
 // --- pure helpers ---
 
 func TestResourceID(t *testing.T) {
-	got := resourceID("default", "Service", "sample")
-	want := "/planes/kubernetes/local/namespaces/default/providers/core/Service/sample"
+	got := resourceID("default", "apps", "Deployment", "sample")
+	want := "/planes/kubernetes/local/namespaces/default/providers/apps/Deployment/sample"
 	if got != want {
 		t.Errorf("resourceID = %q, want %q", got, want)
+	}
+}
+
+func TestConnectionURI(t *testing.T) {
+	got := ConnectionURI("pguser_ab", "pw-123", "sample.default.svc.cluster.local", "5432", "orders_9f")
+	if got != "postgresql://pguser_ab:pw-123@sample.default.svc.cluster.local:5432/orders_9f" {
+		t.Errorf("ConnectionURI = %q", got)
+	}
+	inj := ConnectionURI("u", "p", "h", "5432", "db?sslmode=disable&x=/@ ")
+	u, err := url.Parse(inj)
+	if err != nil {
+		t.Fatalf("produced an unparseable URI %q: %v", inj, err)
+	}
+	if u.Scheme != "postgresql" || u.Hostname() != "h" || u.Port() != "5432" || u.RawQuery != "" {
+		t.Errorf("db name corrupted the URI: %q", inj)
+	}
+	if u.Path != "/db?sslmode=disable&x=/@ " {
+		t.Errorf("db name not preserved after decode: %q", u.Path)
 	}
 }
 
@@ -339,50 +278,13 @@ func TestQuoteLiteral(t *testing.T) {
 	}
 }
 
-func TestAdminDSNEscapesCredentials(t *testing.T) {
-	dsn := adminDSN(PGEndpoint{Host: "h", Port: "5432", User: "u", Password: "p@ss:w/rd", Database: "postgres"})
-	if !strings.Contains(dsn, "sslmode=disable") {
-		t.Errorf("expected sslmode=disable in DSN, got %q", dsn)
+func TestWorkloadImageDefault(t *testing.T) {
+	t.Setenv("POSTGRES_WORKLOAD_IMAGE", "")
+	if img := workloadImage(); img != "postgres:18-alpine" {
+		t.Errorf("workloadImage default = %q, want postgres:18-alpine", img)
 	}
-	if !strings.HasPrefix(dsn, "postgres://u:") {
-		t.Errorf("unexpected DSN prefix: %q", dsn)
-	}
-}
-
-func TestConnectionURI(t *testing.T) {
-	// Plain values round-trip verbatim.
-	got := ConnectionURI("pguser_ab", "pw-123", "localhost", "5432", "orders_9f")
-	if got != "postgresql://pguser_ab:pw-123@localhost:5432/orders_9f" {
-		t.Errorf("ConnectionURI = %q", got)
-	}
-	// A database name with URL-special characters must be escaped, not injected
-	// as spurious authority/query/path segments (finding #1).
-	inj := ConnectionURI("u", "p", "h", "5432", "db?sslmode=disable&x=/@ ")
-	u, err := url.Parse(inj)
-	if err != nil {
-		t.Fatalf("produced an unparseable URI %q: %v", inj, err)
-	}
-	if u.Scheme != "postgresql" || u.Hostname() != "h" || u.Port() != "5432" {
-		t.Errorf("authority corrupted by db name: %q (host=%q port=%q)", inj, u.Hostname(), u.Port())
-	}
-	if u.RawQuery != "" {
-		t.Errorf("db name injected a query string: %q", u.RawQuery)
-	}
-	if u.Path != "/db?sslmode=disable&x=/@ " {
-		t.Errorf("db name not preserved after decode: %q", u.Path)
-	}
-}
-
-func TestAdminEndpointDefaults(t *testing.T) {
-	// With no PG_ADMIN_*/POSTGRES_* env set, defaults must be the documented dev values.
-	for _, k := range []string{
-		"PG_ADMIN_HOST", "PG_ADMIN_PORT", "PG_ADMIN_USER", "PG_ADMIN_PASSWORD", "PG_ADMIN_DB",
-		"POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_USER", "POSTGRES_PASSWORD",
-	} {
-		t.Setenv(k, "")
-	}
-	ep := adminEndpoint()
-	if ep.Host != "localhost" || ep.Port != "5432" || ep.User != "postgres" || ep.Database != "postgres" {
-		t.Errorf("unexpected default endpoint: %+v", ep)
+	t.Setenv("POSTGRES_WORKLOAD_IMAGE", "postgres:17")
+	if img := workloadImage(); img != "postgres:17" {
+		t.Errorf("workloadImage override = %q, want postgres:17", img)
 	}
 }

--- a/pkg/activities/config.go
+++ b/pkg/activities/config.go
@@ -6,17 +6,14 @@ import (
 	"time"
 )
 
-// opTimeout bounds an individual DDL statement (CREATE/DROP ROLE/DATABASE) so a
-// statement blocked on a lock cannot hang the activity indefinitely. Env-tunable
-// via PG_OP_TIMEOUT_SECONDS.
-func opTimeout() time.Duration {
-	return time.Duration(atoiOr(env("PG_OP_TIMEOUT_SECONDS", "30"), 30)) * time.Second
+// env returns the value of the environment variable named by key, or fallback
+// when it is unset or empty.
+func env(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
 }
-
-// postgresName is the literal "postgres" used, by PostgreSQL convention, as the
-// default superuser, the maintenance database, the connection URL scheme, and
-// the binding Service's port name. Single-sourced so the value is not repeated.
-const postgresName = "postgres"
 
 // atoiOr parses s as an int, returning fallback on any parse error.
 func atoiOr(s string, fallback int) int {
@@ -26,40 +23,40 @@ func atoiOr(s string, fallback int) int {
 	return fallback
 }
 
-// env returns the value of the environment variable named by key, or fallback
-// when it is unset or empty. Mirrors the os.LookupEnv-with-default pattern used
-// across the project (see .env.example / Makefile `?=` defaults).
-func env(key, fallback string) string {
-	if v, ok := os.LookupEnv(key); ok && v != "" {
-		return v
-	}
-	return fallback
+// opTimeout bounds an individual DDL statement (CREATE/DROP ROLE/DATABASE) so a
+// statement blocked on a lock cannot hang the activity indefinitely. Env-tunable
+// via PG_OP_TIMEOUT_SECONDS.
+func opTimeout() time.Duration {
+	return time.Duration(atoiOr(env("PG_OP_TIMEOUT_SECONDS", "30"), 30)) * time.Second
 }
 
-// PGEndpoint is a reachable PostgreSQL endpoint. The admin endpoint (used to run
-// provisioning DDL) is read from PG_ADMIN_* with sensible dev defaults that fall
-// back to the local POSTGRES_* dev container (see .env.example). The recipe
-// advertises this same endpoint to consumers, so the returned connection URI is
-// genuinely connectable.
+// workloadImage is the PostgreSQL image the recipe deploys as the database
+// workload. Renovate-tracked via the .go customManager in renovate.json.
+func workloadImage() string {
+	// renovate: datasource=docker depName=postgres
+	const defaultImage = "postgres:18-alpine"
+	return env("POSTGRES_WORKLOAD_IMAGE", defaultImage)
+}
+
+// workloadRolloutTimeout bounds how long DeployPostgres waits for the deployed
+// Postgres to become ready. Env-tunable via PG_WORKLOAD_ROLLOUT_TIMEOUT_SECONDS.
+func workloadRolloutTimeout() time.Duration {
+	return time.Duration(atoiOr(env("PG_WORKLOAD_ROLLOUT_TIMEOUT_SECONDS", "120"), 120)) * time.Second
+}
+
+// postgresName is the literal "postgres" used, by PostgreSQL convention, as the
+// superuser, the connection URL scheme, the Service port name, and the workload
+// label. Single-sourced so the value is not repeated.
+const postgresName = "postgres"
+
+// PGEndpoint is a reachable PostgreSQL admin endpoint used to run provisioning
+// DDL. In the workload-deploy model it is built from the deployed workload's
+// node-reachable NodePort address and superuser credentials, not from static env.
 type PGEndpoint struct {
 	Host     string
 	Port     string
 	User     string
 	Password string
-	// Database is the maintenance database the admin connection targets
-	// (e.g. "postgres"); provisioned databases are created on the same server.
+	// Database is the maintenance database the admin connection targets.
 	Database string
-}
-
-// adminEndpoint resolves the PostgreSQL admin endpoint from the environment.
-// PG_ADMIN_* take precedence; each falls back to the POSTGRES_* dev defaults so
-// a bare `make run` / `make e2e` works against the local dev container.
-func adminEndpoint() PGEndpoint {
-	return PGEndpoint{
-		Host:     env("PG_ADMIN_HOST", env("POSTGRES_HOST", "localhost")),
-		Port:     env("PG_ADMIN_PORT", env("POSTGRES_PORT", "5432")),
-		User:     env("PG_ADMIN_USER", env("POSTGRES_USER", postgresName)),
-		Password: env("PG_ADMIN_PASSWORD", env("POSTGRES_PASSWORD", "daprrulz")),
-		Database: env("PG_ADMIN_DB", postgresName),
-	}
 }

--- a/pkg/activities/kubeclient.go
+++ b/pkg/activities/kubeclient.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,28 +17,30 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// BindingConnection is the connection information published to the cluster so
-// in-cluster consumers can reach the provisioned database.
-type BindingConnection struct {
-	Host     string
-	Port     string
-	Username string
-	Password string
-	Database string
-	URI      string
+// PostgresDeployment describes a Postgres workload the recipe deployed into the
+// cluster: its Radius-style resource ids, the in-cluster Service DNS consumers
+// use, and a host-reachable admin endpoint (node InternalIP + NodePort) the
+// workflow uses to run provisioning DDL from outside the cluster.
+type PostgresDeployment struct {
+	Resources     []string `json:"resources"`
+	InClusterHost string   `json:"inClusterHost"` // <name>.<ns>.svc.cluster.local
+	Port          string   `json:"port"`          // in-cluster port (5432)
+	AdminUser     string   `json:"adminUser"`     // postgres superuser
+	AdminPassword string   `json:"adminPassword"`
+	ReachableHost string   `json:"reachableHost"` // node InternalIP (host-reachable on kind)
+	ReachablePort string   `json:"reachablePort"` // NodePort
 }
 
-// kubeBinder publishes/removes the Kubernetes objects that represent a
-// provisioned database binding (a Service + a Secret). Small interface so
-// activities are unit-testable against a fake with no cluster.
-type kubeBinder interface {
-	EnsureBinding(ctx context.Context, namespace, name string, conn BindingConnection) ([]string, error)
-	DeleteBinding(ctx context.Context, namespace, name string) error
+// kubeDeployer deploys/removes a Postgres workload (Deployment + Service +
+// Secret). Small interface so activities are unit-testable against a fake.
+type kubeDeployer interface {
+	DeployPostgres(ctx context.Context, namespace, name string) (PostgresDeployment, error)
+	DeletePostgres(ctx context.Context, namespace, name string) error
 }
 
-// newKubeBinder constructs a kubeBinder from ambient kubeconfig / in-cluster
+// newKubeDeployer constructs a kubeDeployer from ambient kubeconfig / in-cluster
 // config. Package-level var so tests can substitute a fake.
-var newKubeBinder = func(ctx context.Context) (kubeBinder, error) {
+var newKubeDeployer = func(_ context.Context) (kubeDeployer, error) {
 	cfg, err := restConfig()
 	if err != nil {
 		return nil, fmt.Errorf("loading kubernetes config: %w", err)
@@ -44,7 +49,7 @@ var newKubeBinder = func(ctx context.Context) (kubeBinder, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building kubernetes client: %w", err)
 	}
-	return &clientsetBinder{client: clientset}, nil
+	return &clientsetDeployer{client: clientset}, nil
 }
 
 // restConfig resolves a client config: kubeconfig (KUBECONFIG / ~/.kube/config)
@@ -63,108 +68,224 @@ func restConfig() (*rest.Config, error) {
 	return inCluster, nil
 }
 
-const managedByLabel = "dapr-go-workflow-k8s"
+const (
+	managedByLabel = "dapr-go-workflow-k8s"
+	instanceLabel  = "app.kubernetes.io/instance"
+	postgresPort   = int32(5432)
+)
 
-type clientsetBinder struct {
+type clientsetDeployer struct {
 	client kubernetes.Interface
 }
 
-// resourceID renders a Radius-style resource id for a namespaced core resource.
-func resourceID(namespace, kind, name string) string {
-	return fmt.Sprintf("/planes/kubernetes/local/namespaces/%s/providers/core/%s/%s", namespace, kind, name)
+// resourceID renders a Radius-style resource id for a namespaced resource.
+func resourceID(namespace, provider, kind, name string) string {
+	return fmt.Sprintf("/planes/kubernetes/local/namespaces/%s/providers/%s/%s/%s", namespace, provider, kind, name)
 }
 
-func bindingLabels(name string) map[string]string {
+func workloadLabels(name string) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/managed-by": managedByLabel,
-		"app.kubernetes.io/instance":   name,
+		instanceLabel:                  name,
+		"app.kubernetes.io/name":       postgresName,
 	}
 }
 
-// EnsureBinding creates (or updates) a Secret holding the connection info and a
-// Service that represents the database endpoint. Idempotent so workflow activity
-// retries are safe.
-func (b *clientsetBinder) EnsureBinding(ctx context.Context, namespace, name string, conn BindingConnection) ([]string, error) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: bindingLabels(name)},
-		Type:       corev1.SecretTypeOpaque,
-		StringData: map[string]string{
-			"host":     conn.Host,
-			"port":     conn.Port,
-			"username": conn.Username,
-			"password": conn.Password,
-			"database": conn.Database,
-			"uri":      conn.URI,
-		},
+// DeployPostgres creates (idempotently) the Postgres workload and, once the
+// rollout is complete, returns the deployment info including a host-reachable
+// admin endpoint. createWorkloadObjects is split out so it is unit-testable
+// against a fake clientset; the rollout/endpoint discovery needs a real cluster
+// (covered by make e2e).
+func (d *clientsetDeployer) DeployPostgres(ctx context.Context, namespace, name string) (PostgresDeployment, error) {
+	password, resources, err := d.createWorkloadObjects(ctx, namespace, name)
+	if err != nil {
+		return PostgresDeployment{}, err
 	}
-	if err := b.applySecret(ctx, namespace, secret); err != nil {
-		return nil, err
+	host, port, err := d.waitAndDiscover(ctx, namespace, name)
+	if err != nil {
+		return PostgresDeployment{}, err
 	}
-
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: bindingLabels(name)},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{{
-				Name:       postgresName,
-				Port:       5432,
-				TargetPort: intstr.FromInt32(5432),
-			}},
-		},
-	}
-	if err := b.applyService(ctx, namespace, service); err != nil {
-		return nil, err
-	}
-
-	return []string{
-		resourceID(namespace, "Service", name),
-		resourceID(namespace, "Secret", name),
+	return PostgresDeployment{
+		Resources:     resources,
+		InClusterHost: fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
+		Port:          "5432",
+		AdminUser:     postgresName,
+		AdminPassword: password,
+		ReachableHost: host,
+		ReachablePort: port,
 	}, nil
 }
 
-func (b *clientsetBinder) applySecret(ctx context.Context, namespace string, secret *corev1.Secret) error {
-	secrets := b.client.CoreV1().Secrets(namespace)
-	_, err := secrets.Create(ctx, secret, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		existing, getErr := secrets.Get(ctx, secret.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return fmt.Errorf("getting secret %q: %w", secret.Name, getErr)
-		}
-		existing.StringData = secret.StringData
-		existing.Labels = secret.Labels
-		if _, err = secrets.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("updating secret %q: %w", secret.Name, err)
-		}
-		return nil
-	}
+// createWorkloadObjects ensures the Secret (superuser password), Deployment
+// (postgres image), and NodePort Service exist. Idempotent: an existing Secret's
+// password is reused (the running pod's env can't be changed after start), and
+// existing Deployment/Service are left as-is. Returns the superuser password and
+// the created resource ids.
+func (d *clientsetDeployer) createWorkloadObjects(ctx context.Context, namespace, name string) (password string, resources []string, err error) {
+	password, err = d.ensureSuperuserSecret(ctx, namespace, name)
 	if err != nil {
-		return fmt.Errorf("creating secret %q: %w", secret.Name, err)
+		return "", nil, err
+	}
+	if err := d.ensureDeployment(ctx, namespace, name); err != nil {
+		return "", nil, err
+	}
+	if err := d.ensureService(ctx, namespace, name); err != nil {
+		return "", nil, err
+	}
+	return password, []string{
+		resourceID(namespace, "apps", "Deployment", name),
+		resourceID(namespace, "core", "Service", name),
+		resourceID(namespace, "core", "Secret", name),
+	}, nil
+}
+
+const superuserEnvName = "POSTGRES_PASSWORD"
+
+func (d *clientsetDeployer) ensureSuperuserSecret(ctx context.Context, namespace, name string) (string, error) {
+	secrets := d.client.CoreV1().Secrets(namespace)
+	if existing, err := secrets.Get(ctx, name, metav1.GetOptions{}); err == nil {
+		if pw := string(existing.Data[superuserEnvName]); pw != "" {
+			return pw, nil // reuse — the running pod already uses this password
+		}
+		if pw := existing.StringData[superuserEnvName]; pw != "" {
+			return pw, nil
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("getting secret %q: %w", name, err)
+	}
+
+	password := uuid.NewString()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: workloadLabels(name)},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{superuserEnvName: password},
+	}
+	if _, err := secrets.Create(ctx, secret, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return "", fmt.Errorf("creating secret %q: %w", name, err)
+	}
+	return password, nil
+}
+
+func (d *clientsetDeployer) ensureDeployment(ctx context.Context, namespace, name string) error {
+	replicas := int32(1)
+	labels := workloadLabels(name)
+	selector := map[string]string{instanceLabel: name}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: selector},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  postgresName,
+						Image: workloadImage(),
+						Ports: []corev1.ContainerPort{{ContainerPort: postgresPort}},
+						Env: []corev1.EnvVar{{
+							Name: superuserEnvName,
+							ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: name},
+								Key:                  superuserEnvName,
+							}},
+						}},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{
+								Command: []string{"pg_isready", "-U", postgresName},
+							}},
+							InitialDelaySeconds: 3,
+							PeriodSeconds:       3,
+						},
+					}},
+				},
+			},
+		},
+	}
+	_, err := d.client.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating deployment %q: %w", name, err)
 	}
 	return nil
 }
 
-func (b *clientsetBinder) applyService(ctx context.Context, namespace string, service *corev1.Service) error {
-	services := b.client.CoreV1().Services(namespace)
-	_, err := services.Create(ctx, service, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		// The binding Service already exists and is left as-is: its ClusterIP is
-		// immutable and nothing else about it changes across re-publishes. (The
-		// connection details live in the Secret, which applySecret does refresh.)
-		return nil
+func (d *clientsetDeployer) ensureService(ctx context.Context, namespace, name string) error {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: workloadLabels(name)},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeNodePort,
+			Selector: map[string]string{instanceLabel: name},
+			Ports: []corev1.ServicePort{{
+				Name:       postgresName,
+				Port:       postgresPort,
+				TargetPort: intstr.FromInt32(postgresPort),
+			}},
+		},
 	}
-	if err != nil {
-		return fmt.Errorf("creating service %q: %w", service.Name, err)
+	_, err := d.client.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating service %q: %w", name, err)
 	}
 	return nil
 }
 
-// DeleteBinding removes the Service and Secret, ignoring NotFound.
-func (b *clientsetBinder) DeleteBinding(ctx context.Context, namespace, name string) error {
-	svcErr := b.client.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+// waitAndDiscover blocks until the Deployment has a ready replica, then returns
+// a host-reachable endpoint (a node InternalIP + the Service NodePort). On kind
+// the node InternalIP is a docker-network address routable from the host.
+func (d *clientsetDeployer) waitAndDiscover(ctx context.Context, namespace, name string) (host, port string, err error) {
+	deadline := time.Now().Add(workloadRolloutTimeout())
+	for {
+		dep, err := d.client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return "", "", fmt.Errorf("getting deployment %q: %w", name, err)
+		}
+		if dep.Status.ReadyReplicas >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			return "", "", fmt.Errorf("deployment %q not ready within %s", name, workloadRolloutTimeout())
+		}
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	svc, err := d.client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("getting service %q: %w", name, err)
+	}
+	if len(svc.Spec.Ports) == 0 || svc.Spec.Ports[0].NodePort == 0 {
+		return "", "", fmt.Errorf("service %q has no NodePort assigned", name)
+	}
+	nodePort := fmt.Sprintf("%d", svc.Spec.Ports[0].NodePort)
+
+	nodes, err := d.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("listing nodes: %w", err)
+	}
+	for i := range nodes.Items {
+		for _, addr := range nodes.Items[i].Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP && addr.Address != "" {
+				return addr.Address, nodePort, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("no node InternalIP found for reachable endpoint")
+}
+
+// DeletePostgres removes the Deployment, Service, and Secret (destroying the
+// instance and everything in it), ignoring NotFound.
+func (d *clientsetDeployer) DeletePostgres(ctx context.Context, namespace, name string) error {
+	depErr := d.client.AppsV1().Deployments(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if depErr != nil && !apierrors.IsNotFound(depErr) {
+		return fmt.Errorf("deleting deployment %q: %w", name, depErr)
+	}
+	svcErr := d.client.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if svcErr != nil && !apierrors.IsNotFound(svcErr) {
 		return fmt.Errorf("deleting service %q: %w", name, svcErr)
 	}
-	secErr := b.client.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	secErr := d.client.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if secErr != nil && !apierrors.IsNotFound(secErr) {
 		return fmt.Errorf("deleting secret %q: %w", name, secErr)
 	}

--- a/pkg/activities/kubeclient_test.go
+++ b/pkg/activities/kubeclient_test.go
@@ -4,113 +4,149 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// These tests exercise the REAL clientsetBinder against client-go's in-memory
-// fake clientset — hermetic (no cluster), yet covering the actual create/
-// update/delete/idempotency logic.
+// These tests exercise the REAL clientsetDeployer against client-go's in-memory
+// fake clientset — hermetic (no cluster), covering object creation, idempotency,
+// deletion, and endpoint discovery.
 
-func TestClientsetBinderEnsureBinding(t *testing.T) {
+func TestCreateWorkloadObjects(t *testing.T) {
 	cs := fake.NewSimpleClientset()
-	b := &clientsetBinder{client: cs}
+	d := &clientsetDeployer{client: cs}
 	ctx := context.Background()
 
-	conn := BindingConnection{
-		Host: "localhost", Port: "5432", Username: "u", Password: "p",
-		Database: "db_1", URI: "postgresql://u:p@localhost:5432/db_1",
-	}
-	ids, err := b.EnsureBinding(ctx, "default", "sample", conn)
+	pw, ids, err := d.createWorkloadObjects(ctx, "default", "sample")
 	if err != nil {
-		t.Fatalf("EnsureBinding: %v", err)
+		t.Fatalf("createWorkloadObjects: %v", err)
 	}
-	if len(ids) != 2 {
-		t.Fatalf("expected 2 resource ids, got %v", ids)
+	if pw == "" {
+		t.Error("expected a generated superuser password")
+	}
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 resource ids, got %v", ids)
 	}
 
 	sec, err := cs.CoreV1().Secrets("default").Get(ctx, "sample", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("secret not created: %v", err)
 	}
-	if sec.StringData["uri"] != conn.URI || sec.StringData["database"] != "db_1" {
-		t.Errorf("secret data mismatch: %+v", sec.StringData)
+	if sec.StringData[superuserEnvName] != pw {
+		t.Errorf("secret password mismatch: %+v", sec.StringData)
 	}
-	if sec.Labels["app.kubernetes.io/managed-by"] != managedByLabel {
-		t.Errorf("missing managed-by label: %+v", sec.Labels)
+
+	dep, err := cs.AppsV1().Deployments("default").Get(ctx, "sample", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("deployment not created: %v", err)
+	}
+	c := dep.Spec.Template.Spec.Containers[0]
+	if c.Image != workloadImage() {
+		t.Errorf("deployment image = %q, want %q", c.Image, workloadImage())
+	}
+	if c.Env[0].ValueFrom.SecretKeyRef.Name != "sample" || c.Env[0].Name != superuserEnvName {
+		t.Errorf("POSTGRES_PASSWORD not wired from the secret: %+v", c.Env)
 	}
 
 	svc, err := cs.CoreV1().Services("default").Get(ctx, "sample", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("service not created: %v", err)
 	}
-	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 5432 {
-		t.Errorf("unexpected service ports: %+v", svc.Spec.Ports)
+	if svc.Spec.Type != corev1.ServiceTypeNodePort || svc.Spec.Ports[0].Port != postgresPort {
+		t.Errorf("service not a NodePort on 5432: %+v", svc.Spec)
 	}
 }
 
-func TestClientsetBinderEnsureBindingIsIdempotent(t *testing.T) {
+func TestCreateWorkloadObjectsIsIdempotent(t *testing.T) {
 	cs := fake.NewSimpleClientset()
-	b := &clientsetBinder{client: cs}
+	d := &clientsetDeployer{client: cs}
 	ctx := context.Background()
 
-	conn := BindingConnection{Host: "h", Port: "5432", Username: "u", Password: "p", Database: "db", URI: "u1"}
-	if _, err := b.EnsureBinding(ctx, "default", "sample", conn); err != nil {
-		t.Fatalf("first EnsureBinding: %v", err)
-	}
-
-	// Second call with rotated credentials must succeed (update path) and refresh
-	// the secret without duplicating objects.
-	conn.URI = "u2"
-	conn.Password = "p2"
-	if _, err := b.EnsureBinding(ctx, "default", "sample", conn); err != nil {
-		t.Fatalf("second EnsureBinding: %v", err)
-	}
-
-	sec, err := cs.CoreV1().Secrets("default").Get(ctx, "sample", metav1.GetOptions{})
+	pw1, _, err := d.createWorkloadObjects(ctx, "default", "sample")
 	if err != nil {
-		t.Fatalf("secret get: %v", err)
+		t.Fatalf("first: %v", err)
 	}
-	if sec.StringData["uri"] != "u2" || sec.StringData["password"] != "p2" {
-		t.Errorf("secret not refreshed on second ensure: %+v", sec.StringData)
+	pw2, _, err := d.createWorkloadObjects(ctx, "default", "sample")
+	if err != nil {
+		t.Fatalf("second: %v", err)
 	}
-
-	secList, _ := cs.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
-	if len(secList.Items) != 1 {
-		t.Errorf("expected exactly 1 secret, got %d", len(secList.Items))
+	// The running pod's password can't change after start, so a re-deploy must
+	// reuse the existing secret's password.
+	if pw1 != pw2 {
+		t.Errorf("re-deploy rotated the superuser password (%q -> %q); must reuse", pw1, pw2)
+	}
+	secs, _ := cs.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+	deps, _ := cs.AppsV1().Deployments("default").List(ctx, metav1.ListOptions{})
+	if len(secs.Items) != 1 || len(deps.Items) != 1 {
+		t.Errorf("expected exactly 1 secret and 1 deployment, got %d/%d", len(secs.Items), len(deps.Items))
 	}
 }
 
-func TestClientsetBinderDeleteBinding(t *testing.T) {
+func TestWaitAndDiscover(t *testing.T) {
+	ready := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{{Port: postgresPort, NodePort: 31000}},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "kind-control-plane"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeHostName, Address: "kind-control-plane"},
+			{Type: corev1.NodeInternalIP, Address: "172.18.0.9"},
+		}},
+	}
+	cs := fake.NewSimpleClientset(ready, svc, node)
+	d := &clientsetDeployer{client: cs}
+
+	host, port, err := d.waitAndDiscover(context.Background(), "default", "sample")
+	if err != nil {
+		t.Fatalf("waitAndDiscover: %v", err)
+	}
+	if host != "172.18.0.9" || port != "31000" {
+		t.Errorf("discovered endpoint = %s:%s, want 172.18.0.9:31000", host, port)
+	}
+}
+
+func TestDeletePostgres(t *testing.T) {
 	cs := fake.NewSimpleClientset()
-	b := &clientsetBinder{client: cs}
+	d := &clientsetDeployer{client: cs}
 	ctx := context.Background()
 
-	conn := BindingConnection{Host: "h", Port: "5432", Username: "u", Password: "p", Database: "db", URI: "u"}
-	if _, err := b.EnsureBinding(ctx, "default", "sample", conn); err != nil {
-		t.Fatalf("EnsureBinding: %v", err)
+	if _, _, err := d.createWorkloadObjects(ctx, "default", "sample"); err != nil {
+		t.Fatalf("createWorkloadObjects: %v", err)
 	}
-
-	if err := b.DeleteBinding(ctx, "default", "sample"); err != nil {
-		t.Fatalf("DeleteBinding: %v", err)
+	if err := d.DeletePostgres(ctx, "default", "sample"); err != nil {
+		t.Fatalf("DeletePostgres: %v", err)
 	}
-	if _, err := cs.CoreV1().Secrets("default").Get(ctx, "sample", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
-		t.Errorf("secret should be gone, got err=%v", err)
+	if _, err := cs.AppsV1().Deployments("default").Get(ctx, "sample", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("deployment should be gone, got %v", err)
 	}
 	if _, err := cs.CoreV1().Services("default").Get(ctx, "sample", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
-		t.Errorf("service should be gone, got err=%v", err)
+		t.Errorf("service should be gone, got %v", err)
 	}
-
-	// DeleteBinding again is idempotent (NotFound ignored).
-	if err := b.DeleteBinding(ctx, "default", "sample"); err != nil {
-		t.Errorf("second DeleteBinding should be a no-op, got %v", err)
+	if _, err := cs.CoreV1().Secrets("default").Get(ctx, "sample", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("secret should be gone, got %v", err)
+	}
+	// Idempotent: a second delete is a no-op.
+	if err := d.DeletePostgres(ctx, "default", "sample"); err != nil {
+		t.Errorf("second DeletePostgres should be a no-op, got %v", err)
 	}
 }
 
-func TestBindingLabels(t *testing.T) {
-	l := bindingLabels("sample")
-	if l["app.kubernetes.io/managed-by"] != managedByLabel || l["app.kubernetes.io/instance"] != "sample" {
+func TestWorkloadLabels(t *testing.T) {
+	l := workloadLabels("sample")
+	if l["app.kubernetes.io/managed-by"] != managedByLabel ||
+		l["app.kubernetes.io/instance"] != "sample" ||
+		l["app.kubernetes.io/name"] != postgresName {
 		t.Errorf("unexpected labels: %+v", l)
 	}
 }

--- a/pkg/activities/kubernetes.go
+++ b/pkg/activities/kubernetes.go
@@ -6,13 +6,13 @@ import (
 	"github.com/dapr/durabletask-go/workflow"
 )
 
-func CallDeployKubernetesResources(ctx *workflow.WorkflowContext, input DeployKubernetesResourcesInput) (DeployKubernetesResourcesOutput, error) {
+func CallDeployKubernetesResources(ctx *workflow.WorkflowContext, input DeployKubernetesResourcesInput) (PostgresDeployment, error) {
 	task := ctx.CallActivity(DeployKubernetesResources, workflow.WithActivityInput(input))
 
-	output := DeployKubernetesResourcesOutput{}
+	output := PostgresDeployment{}
 	err := task.Await(&output)
 	if err != nil {
-		return DeployKubernetesResourcesOutput{}, err
+		return PostgresDeployment{}, err
 	}
 
 	return output, nil
@@ -21,23 +21,12 @@ func CallDeployKubernetesResources(ctx *workflow.WorkflowContext, input DeployKu
 type DeployKubernetesResourcesInput struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
-	// Connection info published to the cluster as a Secret so in-cluster
-	// consumers can reach the provisioned database.
-	Host     string `json:"host"`
-	Port     string `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Database string `json:"database"`
-	URI      string `json:"uri"`
 }
 
-type DeployKubernetesResourcesOutput struct {
-	Resources []string `json:"resources"`
-}
-
-// DeployKubernetesResources publishes the database binding (a Service + a Secret)
-// into the target namespace via the Kubernetes API and returns the created
-// resource ids.
+// DeployKubernetesResources deploys a real PostgreSQL workload (Deployment +
+// Service + Secret) into the target namespace and waits for it to be ready. It
+// returns a PostgresDeployment: the in-cluster Service DNS the recipe advertises
+// plus the host-reachable superuser endpoint the workflow uses to run DDL.
 func DeployKubernetesResources(ctx workflow.ActivityContext) (any, error) {
 	input := DeployKubernetesResourcesInput{}
 	if err := ctx.GetInput(&input); err != nil {
@@ -45,28 +34,22 @@ func DeployKubernetesResources(ctx workflow.ActivityContext) (any, error) {
 	}
 
 	logger := slog.Default()
-	logger.Info("Publishing Kubernetes binding",
+	logger.Info("Deploying PostgreSQL workload",
 		slog.String("namespace", input.Namespace), slog.String("name", input.Name))
 
-	binder, err := newKubeBinder(ctx.Context())
+	deployer, err := newKubeDeployer(ctx.Context())
 	if err != nil {
 		return nil, err
 	}
 
-	resources, err := binder.EnsureBinding(ctx.Context(), input.Namespace, input.Name, BindingConnection{
-		Host:     input.Host,
-		Port:     input.Port,
-		Username: input.Username,
-		Password: input.Password,
-		Database: input.Database,
-		URI:      input.URI,
-	})
+	dep, err := deployer.DeployPostgres(ctx.Context(), input.Namespace, input.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Info("Published Kubernetes binding", slog.Int("resources", len(resources)))
-	return DeployKubernetesResourcesOutput{Resources: resources}, nil
+	logger.Info("PostgreSQL workload ready",
+		slog.String("host", dep.InClusterHost), slog.Int("resources", len(dep.Resources)))
+	return dep, nil
 }
 
 func CallDeleteKubernetesResources(ctx *workflow.WorkflowContext, input DeleteKubernetesResourcesInput) (DeleteKubernetesResourcesOutput, error) {
@@ -89,8 +72,8 @@ type DeleteKubernetesResourcesInput struct {
 type DeleteKubernetesResourcesOutput struct {
 }
 
-// DeleteKubernetesResources removes the database binding (Service + Secret) from
-// the target namespace via the Kubernetes API.
+// DeleteKubernetesResources destroys the PostgreSQL workload (Deployment +
+// Service + Secret) — and with it the database and roles it held.
 func DeleteKubernetesResources(ctx workflow.ActivityContext) (any, error) {
 	input := DeleteKubernetesResourcesInput{}
 	if err := ctx.GetInput(&input); err != nil {
@@ -98,15 +81,15 @@ func DeleteKubernetesResources(ctx workflow.ActivityContext) (any, error) {
 	}
 
 	logger := slog.Default()
-	logger.Info("Deleting Kubernetes binding",
+	logger.Info("Deleting PostgreSQL workload",
 		slog.String("namespace", input.Namespace), slog.String("name", input.Name))
 
-	binder, err := newKubeBinder(ctx.Context())
+	deployer, err := newKubeDeployer(ctx.Context())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := binder.DeleteBinding(ctx.Context(), input.Namespace, input.Name); err != nil {
+	if err := deployer.DeletePostgres(ctx.Context(), input.Namespace, input.Name); err != nil {
 		return nil, err
 	}
 

--- a/pkg/activities/pgclient.go
+++ b/pkg/activities/pgclient.go
@@ -3,12 +3,8 @@ package activities
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -20,17 +16,13 @@ import (
 type pgAdmin interface {
 	CreateRole(ctx context.Context, username, password string) error
 	CreateDatabase(ctx context.Context, database, owner string) error
-	DropDatabase(ctx context.Context, database string, backup bool) error
-	DropRole(ctx context.Context, username string) error
 	Close(ctx context.Context) error
 }
 
 // newPGAdmin constructs a pgAdmin connected to the admin endpoint. It is a
 // package-level variable so tests can substitute a fake (hermetic unit tests,
 // no network); production code never reassigns it.
-var newPGAdmin = func(ctx context.Context) (pgAdmin, error) {
-	return dialPGAdmin(ctx, adminEndpoint())
-}
+var newPGAdmin = dialPGAdmin
 
 // connectTimeout bounds the admin connection dial (env-tunable).
 func connectTimeout() time.Duration {
@@ -140,66 +132,6 @@ func (a *pgxAdmin) CreateDatabase(ctx context.Context, database, owner string) e
 		return fmt.Errorf("creating database %q: %w", database, err)
 	}
 	return nil
-}
-
-// DropDatabase optionally takes a best-effort logical backup (pg_dump, if the
-// binary is on PATH) then drops the database. WITH (FORCE) terminates lingering
-// connections (PostgreSQL 13+).
-func (a *pgxAdmin) DropDatabase(ctx context.Context, database string, backup bool) error {
-	if backup {
-		a.backupDatabase(ctx, database)
-	}
-	// Bound only the DROP itself (the best-effort backup above may legitimately
-	// take longer than a single-statement timeout).
-	dctx, cancel := context.WithTimeout(ctx, opTimeout())
-	defer cancel()
-	_, err := a.conn.Exec(dctx, fmt.Sprintf(
-		"DROP DATABASE IF EXISTS %s WITH (FORCE)",
-		pgx.Identifier{database}.Sanitize()))
-	if err != nil {
-		return fmt.Errorf("dropping database %q: %w", database, err)
-	}
-	return nil
-}
-
-// DropRole drops the role idempotently.
-func (a *pgxAdmin) DropRole(ctx context.Context, username string) error {
-	ctx, cancel := context.WithTimeout(ctx, opTimeout())
-	defer cancel()
-
-	_, err := a.conn.Exec(ctx, fmt.Sprintf(
-		"DROP ROLE IF EXISTS %s", pgx.Identifier{username}.Sanitize()))
-	if err != nil {
-		return fmt.Errorf("dropping role %q: %w", username, err)
-	}
-	return nil
-}
-
-// backupDatabase runs pg_dump to PG_BACKUP_DIR when the tool is available. It is
-// best-effort: a missing pg_dump logs a skip rather than failing the delete
-// (the drop is the real, required side effect). The admin password is passed via
-// PGPASSWORD in the child env, never on argv (secret-handling rule).
-func (a *pgxAdmin) backupDatabase(ctx context.Context, database string) {
-	logger := slog.Default()
-	pgDump, err := exec.LookPath("pg_dump")
-	if err != nil {
-		logger.Info("pg_dump not found on PATH; skipping backup", slog.String("database", database))
-		return
-	}
-	dir := env("PG_BACKUP_DIR", os.TempDir())
-	outFile := filepath.Join(dir, database+".sql")
-	// #nosec G204 -- pgDump is resolved via LookPath; args are the configured
-	// admin endpoint and a server-generated database name, not external input.
-	cmd := exec.CommandContext(ctx, pgDump,
-		"-h", a.endpoint.Host, "-p", a.endpoint.Port, "-U", a.endpoint.User,
-		"-d", database, "-f", outFile)
-	cmd.Env = append(os.Environ(), "PGPASSWORD="+a.endpoint.Password)
-	if err := cmd.Run(); err != nil {
-		logger.Warn("pg_dump backup failed; proceeding with drop",
-			slog.String("database", database), slog.Any("error", err))
-		return
-	}
-	logger.Info("Created database backup", slog.String("database", database), slog.String("file", outFile))
 }
 
 // quoteLiteral single-quotes a string literal for inline DDL, escaping embedded

--- a/pkg/activities/postgres.go
+++ b/pkg/activities/postgres.go
@@ -8,10 +8,30 @@ import (
 	"github.com/google/uuid"
 )
 
-// shortID returns 8 hex characters suitable for a unique, DNS/identifier-safe
-// suffix on generated role and database names.
+// shortID returns 8 hex characters suitable for a unique, identifier-safe suffix
+// on generated role and database names.
 func shortID() string {
 	return strings.ReplaceAll(uuid.NewString(), "-", "")[:8]
+}
+
+// AdminConn carries the host-reachable superuser endpoint of the deployed
+// Postgres (threaded from DeployKubernetesResources) that the provisioning DDL
+// connects to.
+type AdminConn struct {
+	AdminHost     string `json:"adminHost"`
+	AdminPort     string `json:"adminPort"`
+	AdminUser     string `json:"adminUser"`
+	AdminPassword string `json:"adminPassword"`
+}
+
+func (a AdminConn) endpoint() PGEndpoint {
+	return PGEndpoint{
+		Host:     a.AdminHost,
+		Port:     a.AdminPort,
+		User:     a.AdminUser,
+		Password: a.AdminPassword,
+		Database: postgresName, // maintenance DB
+	}
 }
 
 func CallCreatePostgresUser(ctx *workflow.WorkflowContext, input CreatePostgresUserInput) (CreatePostgresUserOutput, error) {
@@ -27,9 +47,10 @@ func CallCreatePostgresUser(ctx *workflow.WorkflowContext, input CreatePostgresU
 }
 
 type CreatePostgresUserInput struct {
-	// Username, when non-empty, reuses an existing role (idempotent update): the
-	// role's password is rotated rather than a new role being created. Empty
-	// generates a fresh unique role name.
+	AdminConn
+	// Username, when non-empty, reuses an existing role (idempotent update): its
+	// password is rotated rather than a new role being created. Empty generates a
+	// fresh unique role name.
 	Username string `json:"username,omitempty"`
 }
 
@@ -39,7 +60,7 @@ type CreatePostgresUserOutput struct {
 }
 
 // CreatePostgresUser provisions (or, when Username is supplied, reuses) a LOGIN
-// role on the admin PostgreSQL endpoint with a freshly generated password.
+// role on the deployed PostgreSQL with a freshly generated password.
 func CreatePostgresUser(ctx workflow.ActivityContext) (any, error) {
 	input := CreatePostgresUserInput{}
 	if err := ctx.GetInput(&input); err != nil {
@@ -55,7 +76,7 @@ func CreatePostgresUser(ctx workflow.ActivityContext) (any, error) {
 	logger := slog.Default()
 	logger.Info("Creating postgres role", slog.String("username", username))
 
-	admin, err := newPGAdmin(ctx.Context())
+	admin, err := newPGAdmin(ctx.Context(), input.endpoint())
 	if err != nil {
 		return nil, err
 	}
@@ -71,48 +92,6 @@ func CreatePostgresUser(ctx workflow.ActivityContext) (any, error) {
 	}, nil
 }
 
-func CallDeletePostgresUser(ctx *workflow.WorkflowContext, input DeletePostgresUserInput) (DeletePostgresUserOutput, error) {
-	task := ctx.CallActivity(DeletePostgresUser, workflow.WithActivityInput(input))
-
-	output := DeletePostgresUserOutput{}
-	err := task.Await(&output)
-	if err != nil {
-		return DeletePostgresUserOutput{}, err
-	}
-
-	return output, nil
-}
-
-type DeletePostgresUserInput struct {
-	Username string `json:"username"`
-}
-
-type DeletePostgresUserOutput struct {
-}
-
-// DeletePostgresUser drops the role from the admin PostgreSQL endpoint.
-func DeletePostgresUser(ctx workflow.ActivityContext) (any, error) {
-	input := DeletePostgresUserInput{}
-	if err := ctx.GetInput(&input); err != nil {
-		return nil, err
-	}
-
-	logger := slog.Default()
-	logger.Info("Deleting postgres role", slog.String("username", input.Username))
-
-	admin, err := newPGAdmin(ctx.Context())
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = admin.Close(ctx.Context()) }()
-
-	if err := admin.DropRole(ctx.Context(), input.Username); err != nil {
-		return nil, err
-	}
-
-	return DeletePostgresUserOutput{}, nil
-}
-
 func CallCreatePostgresDatabase(ctx *workflow.WorkflowContext, input CreatePostgresDatabaseInput) (CreatePostgresDatabaseOutput, error) {
 	task := ctx.CallActivity(CreatePostgresDatabase, workflow.WithActivityInput(input))
 
@@ -126,8 +105,8 @@ func CallCreatePostgresDatabase(ctx *workflow.WorkflowContext, input CreatePostg
 }
 
 type CreatePostgresDatabaseInput struct {
+	AdminConn
 	Username       string `json:"username"`
-	Password       string `json:"password"`
 	DatabasePrefix string `json:"databasePrefix"`
 	// Database, when non-empty, reuses an existing database (idempotent update):
 	// CreateDatabase is a no-op if it already exists. Empty generates a fresh
@@ -137,14 +116,10 @@ type CreatePostgresDatabaseInput struct {
 
 type CreatePostgresDatabaseOutput struct {
 	Database string `json:"database"`
-	// Host and Port locate the server the database was created on — the same
-	// reachable admin endpoint — so the recipe's advertised URI is connectable.
-	Host string `json:"host"`
-	Port string `json:"port"`
 }
 
-// CreatePostgresDatabase creates a uniquely named database owned by the role on
-// the admin PostgreSQL endpoint and returns the reachable host/port.
+// CreatePostgresDatabase creates (or reuses) a database owned by the role on the
+// deployed PostgreSQL.
 func CreatePostgresDatabase(ctx workflow.ActivityContext) (any, error) {
 	input := CreatePostgresDatabaseInput{}
 	if err := ctx.GetInput(&input); err != nil {
@@ -159,7 +134,7 @@ func CreatePostgresDatabase(ctx workflow.ActivityContext) (any, error) {
 	logger := slog.Default()
 	logger.Info("Creating database", slog.String("database", database), slog.String("owner", input.Username))
 
-	admin, err := newPGAdmin(ctx.Context())
+	admin, err := newPGAdmin(ctx.Context(), input.endpoint())
 	if err != nil {
 		return nil, err
 	}
@@ -169,54 +144,5 @@ func CreatePostgresDatabase(ctx workflow.ActivityContext) (any, error) {
 		return nil, err
 	}
 
-	ep := adminEndpoint()
-	return CreatePostgresDatabaseOutput{
-		Database: database,
-		Host:     ep.Host,
-		Port:     ep.Port,
-	}, nil
-}
-
-func CallDeletePostgresDatabase(ctx *workflow.WorkflowContext, input DeletePostgresDatabaseInput) (DeletePostgresDatabaseOutput, error) {
-	task := ctx.CallActivity(DeletePostgresDatabase, workflow.WithActivityInput(input))
-
-	output := DeletePostgresDatabaseOutput{}
-	err := task.Await(&output)
-	if err != nil {
-		return DeletePostgresDatabaseOutput{}, err
-	}
-
-	return output, nil
-}
-
-type DeletePostgresDatabaseInput struct {
-	Database     string `json:"database"`
-	CreateBackup bool   `json:"createBackup"`
-}
-
-type DeletePostgresDatabaseOutput struct {
-}
-
-// DeletePostgresDatabase optionally backs up (best-effort pg_dump) then drops the
-// database from the admin PostgreSQL endpoint.
-func DeletePostgresDatabase(ctx workflow.ActivityContext) (any, error) {
-	input := DeletePostgresDatabaseInput{}
-	if err := ctx.GetInput(&input); err != nil {
-		return nil, err
-	}
-
-	logger := slog.Default()
-	logger.Info("Deleting database", slog.String("database", input.Database), slog.Bool("backup", input.CreateBackup))
-
-	admin, err := newPGAdmin(ctx.Context())
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = admin.Close(ctx.Context()) }()
-
-	if err := admin.DropDatabase(ctx.Context(), input.Database, input.CreateBackup); err != nil {
-		return nil, err
-	}
-
-	return DeletePostgresDatabaseOutput{}, nil
+	return CreatePostgresDatabaseOutput{Database: database}, nil
 }

--- a/pkg/workflows/postgresqldatabases.go
+++ b/pkg/workflows/postgresqldatabases.go
@@ -23,58 +23,63 @@ func PostgresSQLDatabasesPut(ctx *workflow.WorkflowContext) (any, error) {
 		logger.Info("Creating/Updating PostgresSQL database")
 	}
 
-	// Idempotent update: if the recipe context carries a prior status.binding
-	// (the same shape PostgresSQLDatabasesDelete reads), reuse those role and
-	// database names — the role's password is rotated and the database ensured —
-	// instead of creating fresh objects and orphaning the old ones. On a first
-	// Put the bindings are empty, so fresh unique names are generated.
-	existingUser, _ := request.Resource.GetStringValue("/status/binding/username")
-	existingDatabase, _ := request.Resource.GetStringValue("/status/binding/database")
+	namespace := request.Runtime.Kubernetes.Namespace
+	name := request.Resource.Name
 
-	// 1. Provision (or reuse) the login role, 2. create (or ensure) the database
-	// it owns (which returns the reachable host/port), then 3. publish the
-	// connection binding into Kubernetes. Ordering matters: the binding Secret
-	// carries the final credentials, so it is published last.
-	credentials, err := activities.CallCreatePostgresUser(ctx, activities.CreatePostgresUserInput{
-		Username: existingUser,
+	// 1. Deploy the PostgreSQL workload (Deployment + Service + Secret) and wait
+	// for it to be ready. This returns the in-cluster Service DNS consumers use
+	// AND a host-reachable superuser endpoint used to run the provisioning DDL.
+	deployed, err := activities.CallDeployKubernetesResources(ctx, activities.DeployKubernetesResourcesInput{
+		Namespace: namespace,
+		Name:      name,
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	admin := activities.AdminConn{
+		AdminHost:     deployed.ReachableHost,
+		AdminPort:     deployed.ReachablePort,
+		AdminUser:     deployed.AdminUser,
+		AdminPassword: deployed.AdminPassword,
+	}
+
+	// Idempotent update: if the recipe context carries a prior status.binding,
+	// reuse those role and database names on the (now redeployed) instance — the
+	// role's password is rotated, the database ensured. A first Put has empty
+	// bindings, so fresh unique names are generated.
+	existingUser, _ := request.Resource.GetStringValue("/status/binding/username")
+	existingDatabase, _ := request.Resource.GetStringValue("/status/binding/database")
+
+	// 2. Provision (or reuse) the login role on the deployed instance.
+	credentials, err := activities.CallCreatePostgresUser(ctx, activities.CreatePostgresUserInput{
+		AdminConn: admin,
+		Username:  existingUser,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Create (or ensure) the database it owns.
 	database, err := activities.CallCreatePostgresDatabase(ctx, activities.CreatePostgresDatabaseInput{
+		AdminConn:      admin,
 		Username:       credentials.Username,
-		Password:       credentials.Password,
-		DatabasePrefix: request.Resource.Name,
+		DatabasePrefix: name,
 		Database:       existingDatabase,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Build the advertised connection URI via url.URL escaping (activities.ConnectionURI)
-	// so a resource-derived database name with URL-special characters cannot corrupt it.
-	uri := activities.ConnectionURI(credentials.Username, credentials.Password, database.Host, database.Port, database.Database)
+	// The recipe advertises the in-cluster Service DNS (what consumers connect
+	// to). ConnectionURI's url.URL escaping keeps a resource-derived database name
+	// from corrupting the connection string.
+	uri := activities.ConnectionURI(credentials.Username, credentials.Password, deployed.InClusterHost, deployed.Port, database.Database)
 
-	deployed, err := activities.CallDeployKubernetesResources(ctx, activities.DeployKubernetesResourcesInput{
-		Namespace: request.Runtime.Kubernetes.Namespace,
-		Name:      request.Resource.Name,
-		Host:      database.Host,
-		Port:      database.Port,
-		Username:  credentials.Username,
-		Password:  credentials.Password,
-		Database:  database.Database,
-		URI:       uri,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Return data to Radius
 	result := recipes.Result{
 		Values: map[string]any{
-			"host":     database.Host,
-			"port":     database.Port,
+			"host":     deployed.InClusterHost,
+			"port":     deployed.Port,
 			"username": credentials.Username,
 			"database": database.Database,
 		},
@@ -103,27 +108,9 @@ func PostgresSQLDatabasesDelete(ctx *workflow.WorkflowContext) (any, error) {
 		logger.Info("Deleting PostgresSQL database")
 	}
 
-	database, ok := request.Resource.GetStringValue("/status/binding/database")
-	if ok {
-		_, err = activities.CallDeletePostgresDatabase(ctx, activities.DeletePostgresDatabaseInput{
-			Database:     database,
-			CreateBackup: true,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	username, ok := request.Resource.GetStringValue("/status/binding/username")
-	if ok {
-		_, err = activities.CallDeletePostgresUser(ctx, activities.DeletePostgresUserInput{
-			Username: username,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
+	// Destroying the workload (Deployment + Service + Secret) destroys the
+	// PostgreSQL instance and every role/database it held — no per-object drop
+	// needed.
 	_, err = activities.CallDeleteKubernetesResources(ctx, activities.DeleteKubernetesResourcesInput{
 		Namespace: request.Runtime.Kubernetes.Namespace,
 		Name:      request.Resource.Name,

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,15 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: registryUrl=(?<registryUrl>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[A-Z0-9_]+\\s*[?:]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track the deployed PostgreSQL workload image (the Go default in workloadImage() and the .env.example mirror) via inline renovate comments.",
+      "managerFilePatterns": ["pkg/activities/config.go", "/^\\.env\\.example$/"],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+const \\w+ = \"[^:\"]+:(?<currentValue>[^\"]+)\"",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+[A-Z_]+=[^:\\s]+:(?<currentValue>\\S+)"
+      ]
     }
   ],
   "commitMessagePrefix": "chore(all): ",


### PR DESCRIPTION
## Summary

The recipe now **deploys a real, dedicated PostgreSQL workload per resource** instead of publishing binding objects.

- **`PostgresSQLDatabasesPut`** (client-go) deploys a `Deployment` (`POSTGRES_WORKLOAD_IMAGE`, default `postgres:18-alpine`) + NodePort `Service` + `Secret` (generated superuser password), waits for the rollout, then runs real `CREATE ROLE` / `CREATE DATABASE` (pgx) **on the deployed instance**, reached from the host via the Service's node-IP:NodePort. Advertises the in-cluster Service DNS + a `url.URL`-escaped connectable URI. Still update-idempotent (reuses `status.binding` role/database on the redeployed instance; existing superuser password kept).
- **`PostgresSQLDatabasesDelete`** destroys the workload (and with it the database + roles).
- Removed the now-unused delete-side PG activities; the admin endpoint is threaded from the deploy (`AdminConn`), not static env.

## Verification

- **`make e2e`** deploys the workload into kind, asserts a **ready Deployment**, that the provisioned role **authenticates to its database on the deployed instance** (node-IP:NodePort), an **idempotent re-Put** (same role+database, exactly one provisioned db, no orphan), then **Delete destroys** the Deployment/Service/Secret. Green end-to-end.
- Unit tests exercise the real `clientsetDeployer` against client-go's fake clientset (object specs, idempotency, `waitAndDiscover`, delete).
- `make ci` green (coverage 48.4%), golangci-lint 0 issues, shellcheck clean, `renovate --platform=local` validates the new image customManager.

## Notes / limitations (documented in CLAUDE.md)

- Ephemeral storage (no PVC) — demo lifecycle, not durability.
- Host-reachability of the deployed instance is kind-specific (node-IP:NodePort, host-routable on Linux/CI).

## Test plan

- [x] `make ci` green
- [x] `make e2e` green (deploy → provision → idempotent re-Put → destroy)
- [ ] CI `ci-pass` green
