### PR TITLE
fix: project-review findings — CI correctness, renovate pin-error, doc fabrications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=daprrulz
 POSTGRES_DB=sample_state
+# Image for the local dev state-store container. Pinned + Renovate-tracked
+# (custom.regex manager) so the dev state store is reproducible.
+# renovate: datasource=docker depName=postgres
+POSTGRES_STATE_IMAGE=postgres:18-alpine
 
 # --- Recipe backend: deployed PostgreSQL workload ---
 # The workflow DEPLOYS a PostgreSQL workload (Deployment + Service + Secret) into

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,21 @@ jobs:
       code: ${{ (startsWith(github.ref, 'refs/tags/') || env.ACT == 'true') && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         if: ${{ !env.ACT }}
         id: filter
         with:
           base: ${{ github.event_name == 'push' && 'main' || '' }}
           filters: |
             code:
-              - '!(**.md|docs/**|LICENSE|.gitignore|.claudeignore|.claude/**|**.png|**.jpg|**.gif|**.svg)'
+              - '!(**.md|docs/**|specs/**|benchmarks/**|LICENSE|.gitignore|.claudeignore|.claude/**|**.png|**.jpg|**.gif|**.svg)'
               - 'CLAUDE.md'
 
   static-check:
     needs: [changes]
-    if: ${{ needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -54,7 +56,8 @@ jobs:
           version: "2026.6.5"
           install: true
           cache: true
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
@@ -64,7 +67,9 @@ jobs:
 
   build:
     needs: [changes, static-check]
-    if: ${{ needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -76,7 +81,8 @@ jobs:
           version: "2026.6.5"
           install: true
           cache: true
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
@@ -86,7 +92,9 @@ jobs:
 
   test:
     needs: [changes, static-check]
-    if: ${{ needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -98,7 +106,8 @@ jobs:
           version: "2026.6.5"
           install: true
           cache: true
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
@@ -119,7 +128,9 @@ jobs:
     # `dapr init`/kind is unreliable there); `make ci-run` exercises only
     # static-check/build/test.
     needs: [changes, build, test]
-    if: ${{ needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    if: |
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -131,12 +142,13 @@ jobs:
           version: "2026.6.5"
           install: true
           cache: true
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: go-mod-${{ runner.os }}-
-      - name: End-to-end workflow test
+      - name: Run end-to-end tests
         run: make e2e
 
   docker:

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   actions: write
+  pull-requests: read   # gh pr list, to exclude open-PR runs from deletion
 
 jobs:
   cleanup-runs:
@@ -25,17 +26,27 @@ jobs:
       - name: Delete old workflow runs
         run: |
           CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          # SHAs backing OPEN PRs — never delete their runs, or an idle PR older
+          # than RETAIN_DAYS loses its CI run and becomes silently un-mergeable
+          # (mergeStateStatus=BLOCKED, 0 checks reported).
+          OPEN_SHAS=$(gh pr list --repo "${{ github.repository }}" --state open \
+            --json headRefOid --jq '[.[].headRefOid]')
           # Retain the newest KEEP_MINIMUM runs PER WORKFLOW (group_by
-          # .workflowName), THEN delete any remaining run older than CUTOFF. A
-          # single GLOBAL minimum can purge every run of a low-frequency
-          # workflow and flip it to state=deleted (deregisters it).
+          # .workflowName), THEN delete any remaining run older than CUTOFF whose
+          # head SHA does not back an open PR. A single GLOBAL minimum can purge
+          # every run of a low-frequency workflow and flip it to state=deleted
+          # (deregisters it).
           gh run list --repo "${{ github.repository }}" \
-            --json databaseId,createdAt,workflowName --limit 300 \
-          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" '
+            --json databaseId,createdAt,workflowName,headSha --limit 300 \
+          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" \
+                --argjson open "$OPEN_SHAS" '
               group_by(.workflowName)
               | map(sort_by(.createdAt) | reverse | .[$keep:])
               | add // []
-              | .[] | select(.createdAt < $cutoff) | .databaseId
+              | .[]
+              | select(.createdAt < $cutoff)
+              | select(.headSha as $s | ($open | index($s)) | not)
+              | .databaseId
             ' \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -18,7 +18,8 @@ go = "1.26.4"
 # Dapr CLI for the e2e target (dapr init + dapr run). The runtime version it
 # installs is pinned separately via DAPR_RUNTIME_VERSION in .env.example/Makefile.
 "aqua:dapr/cli" = "1.18.0"
-# kind + kubectl for the e2e target: the workflow publishes a real Service +
-# Secret binding into a kind cluster that e2e/e2e-test.sh creates and tears down.
+# kind + kubectl for the e2e target: the workflow deploys a real PostgreSQL
+# workload (Deployment + Service + Secret) into a kind cluster that
+# e2e/e2e-test.sh creates and tears down.
 "aqua:kubernetes-sigs/kind" = "0.32.0"
 "aqua:kubernetes/kubectl" = "1.34.9"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,14 @@ make run         # ./run-dapr.sh — dapr run, app-id sample, app-port 7999, grp
 make release     # validate semver, commit version.txt, tag, push
 ```
 
-Run a single test: `go test -run '^TestName$' ./pkg/<pkg>/...`. Skip the slow 5s backup simulation: `go test -short ./...`.
+Run a single test: `go test -run '^TestName$' ./pkg/<pkg>/...`.
+
+Two test layers: `make test` (unit — hermetic, fakes + client-go's in-memory fake clientset, runs in seconds) and `make e2e` (real end-to-end — `dapr init` control plane + a kind cluster + a deployed PostgreSQL workload, runs in minutes). There is no separate integration layer; the pgx-admin and workflow-orchestration paths are covered by `make e2e`.
 
 ### Local end-to-end loop (manual)
 
 ```bash
-make postgres-start  # docker postgres on :5432 (POSTGRES_PASSWORD default daprrulz)
+make postgres-start  # docker postgres on :5432 (POSTGRES_PASSWORD from .env.example)
 make run             # starts the app under a Dapr sidecar (run-dapr.sh → go run ./cmd/main.go)
 ./start-workflow.sh  # health-check, PUT PostgresSQLDatabasesPut, poll runtimeStatus until terminal
 make postgres-stop
@@ -84,7 +86,7 @@ Because the recipe deploys a real workload, running it needs a **kubeconfig** fo
 
 - **Unit-tested**: `pkg/recipes` (100%), `pkg/activities` activity funcs (via a fake `ActivityContext`) + the real `clientsetDeployer` (object creation, idempotency, `waitAndDiscover`, delete — via client-go's in-memory fake clientset in `kubeclient_test.go`), `pkg/server`, `cmd/healthcheck`. `COVERAGE_THRESHOLD` defaults to **40%** because the pgx admin client, the deploy rollout, and the workflow-orchestration funcs are covered by `make e2e`, not unit tests.
 - **`make e2e`** is the real end-to-end test (`e2e/e2e-test.sh`): it `dapr init`s a control plane, starts the state-store PostgreSQL, **creates a kind cluster**, runs the app under a Dapr sidecar (`KUBECONFIG` → kind), schedules `PostgresSQLDatabasesPut`, and verifies the recipe **actually deployed a PostgreSQL workload**: the Deployment has a ready replica, and the provisioned role authenticates to its database **on the deployed instance** (via node-IP:NodePort). It then re-Puts (asserting idempotent reuse with no orphan) and runs `PostgresSQLDatabasesDelete`, asserting the Deployment/Service/Secret are gone. It manages its own kind cluster (`E2E_KIND_KEEP=1` keeps it). Runs in CI (the `e2e` job; kind + kubectl come from mise) and locally.
-- **Dapr runtime ≥ 1.18 is required** (`DAPR_RUNTIME_VERSION`, default 1.18.0). go-sdk v1.15 / durabletask-go v0.12 fail activity invocation on older runtimes with `required metadata dapr-callee-app-id ... not found`.
+- **Dapr runtime ≥ 1.18 is required** (pinned via `DAPR_RUNTIME_VERSION` in `.env.example` / the Makefile). The `dapr/go-sdk` + `durabletask-go` versions in `go.mod` fail activity invocation on older runtimes with `required metadata dapr-callee-app-id ... not found`.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ check-go-alignment:
 		exit 1; \
 	fi
 
+#check-env: @ STOPPER — fail if the committed .env.example source-of-truth is missing
+check-env:
+	@test -f .env.example || { echo "ERROR: .env.example is missing (BLOCKING) — it is the committed source of truth for every operator-tunable value."; exit 1; }
+
 #clean: @ Remove build artifacts
 clean:
 	@rm -f ./cmd/main coverage.out
@@ -147,8 +151,8 @@ mermaid-lint:
 	done; \
 	exit $$rc
 
-#static-check: @ Composite quality gate (alignment + workflow lint + lint + vuln + secrets + trivy + mermaid)
-static-check: check-go-alignment lint-ci lint vulncheck secrets trivy-fs mermaid-lint
+#static-check: @ Composite quality gate (env + alignment + workflow lint + lint + vuln + secrets + trivy + mermaid)
+static-check: check-env check-go-alignment lint-ci lint vulncheck secrets trivy-fs mermaid-lint
 	@echo "Static check passed."
 
 #test: @ Run unit tests with race detector and coverage
@@ -228,6 +232,7 @@ image-build:
 
 #image-run: @ Run the container image locally (needs a Dapr sidecar to be healthy)
 image-run: image-stop
+	@$(MAKE) --no-print-directory check-ports CHECK_PORTS="$(APP_PORT)"
 	@docker run --rm -p $(APP_PORT):$(APP_PORT) -e APP_PORT=$(APP_PORT) --name $(APP_NAME) $(IMAGE_NAME):$(IMAGE_TAG)
 
 #image-stop: @ Stop the local container
@@ -271,18 +276,22 @@ release:
 		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		echo $$newtag > ./version.txt && \
-		git add -A && \
-		git commit -a -s -m "Cut $$newtag release" && \
+		git add version.txt && \
+		git commit -s -m "Cut $$newtag release" && \
 		git tag -a -m "Cut $$newtag release" $$newtag && \
 		git push origin $$newtag && \
 		git push && \
 		echo "Done."'
 
+#renovate-validate: @ Validate renovate.json against the Renovate config schema
+renovate-validate:
+	@npx --yes --package renovate -- renovate-config-validator --strict
+
 #version: @ Print the current version (git tag)
 version:
 	@echo $(CURRENTTAG)
 
-.PHONY: help deps deps-check check-go-alignment clean get update format lint lint-ci \
+.PHONY: help deps deps-check check-go-alignment check-env clean get update format lint lint-ci \
 	vulncheck secrets trivy-fs mermaid-lint static-check test coverage-check check-ports e2e-deps e2e build run \
 	postgres-start postgres-stop image-build image-run image-stop image-push \
-	ci ci-run release version
+	ci ci-run renovate-validate release version

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Reference Go service that drives **[Radius](https://radapp.io/) Recipes** throug
 
 | Component | Technology |
 |-----------|------------|
-| Language | Go 1.26 |
+| Language | Go 1.26.4 |
 | Workflow engine | [Dapr durable workflows](https://docs.dapr.io/developing-applications/building-blocks/workflow/) via `dapr/durabletask-go` v0.12 |
 | Dapr SDK | `dapr/go-sdk` v1.15 (runtime ≥ 1.18) |
-| HTTP | `net/http` + [go-chi/chi](https://github.com/go-chi/chi) router |
+| HTTP | Go stdlib `net/http` (`http.ServeMux`, method + path routing) |
 | Recipe contract | Radius Recipe `Context` / `Result` types (`pkg/recipes`) |
 | PostgreSQL backend | [`jackc/pgx`](https://github.com/jackc/pgx) v5 (real role/database provisioning) |
 | Kubernetes backend | [`k8s.io/client-go`](https://github.com/kubernetes/client-go) (deploys the PostgreSQL Deployment + Service + Secret) |
@@ -50,9 +50,11 @@ make e2e
 | [Git](https://git-scm.com/) | latest | Source control | per-platform |
 | [mise](https://mise.jdx.dev) | latest | Manages the Go toolchain and all quality/security tools | `curl https://mise.run \| sh` (or `make deps`) |
 | [Docker](https://docs.docker.com/get-docker/) | latest | Local PostgreSQL + container image builds | per-platform |
-| [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) | latest | Running the app with a sidecar | `dapr init` |
+| [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) | `.mise.toml`-pinned | Runs the app with a sidecar; `dapr init` bootstraps the runtime | `make deps` (mise) |
+| [kind](https://kind.sigs.k8s.io/) | `.mise.toml`-pinned | Local Kubernetes cluster for `make e2e` | `make deps` (mise) |
+| [kubectl](https://kubernetes.io/docs/reference/kubectl/) | `.mise.toml`-pinned | Talks to the cluster the recipe deploys into | `make deps` (mise) |
 
-`make deps` bootstraps mise and installs the Go toolchain plus `golangci-lint`, `gitleaks`, `trivy`, `hadolint`, `actionlint`, `shellcheck`, `act`, `goreleaser`, and `govulncheck` — all pinned in `.mise.toml`.
+`make deps` bootstraps mise and installs the Go toolchain plus `dapr` (CLI), `kind`, `kubectl`, `golangci-lint`, `gitleaks`, `trivy`, `hadolint`, `actionlint`, `shellcheck`, `act`, `goreleaser`, and `govulncheck` — all pinned in `.mise.toml`.
 
 ## Architecture
 
@@ -114,7 +116,7 @@ All operator-tunable values are documented in [`.env.example`](.env.example). Co
 | `APP_PORT` | `7999` | HTTP listen port (must match the Dapr sidecar `--app-port`) |
 | `DAPR_APP_ID` | `sample` | Dapr application id |
 | `DAPR_GRPC_PORT` | `50001` | Dapr sidecar gRPC port |
-| `POSTGRES_PASSWORD` | `daprrulz` | Local dev PostgreSQL password |
+| `POSTGRES_PASSWORD` | see [`.env.example`](.env.example) | Local dev PostgreSQL superuser password (single source of truth in `.env.example`) |
 | `POSTGRES_PORT` | `5432` | Local dev PostgreSQL port |
 | `POSTGRES_WORKLOAD_IMAGE` | `postgres:18-alpine` | Image the recipe deploys as the database workload (Renovate-tracked) |
 | `KUBECONFIG` | `~/.kube/config` | Cluster the recipe deploys the PostgreSQL workload into (`make e2e` uses its own kind cluster) |
@@ -136,13 +138,14 @@ Run `make help` to see all targets.
 | `make build` | Build the linux/amd64 binary to `./cmd/main` |
 | `make run` | Run the app via the Dapr sidecar |
 | `make check-ports` | Fail early if a guarded host port (Postgres/app/gRPC) is already in use |
+| `make check-env` | STOPPER — fail if the committed `.env.example` source-of-truth is missing |
 | `make clean` | Remove build artifacts |
 
 ### Testing
 
 | Target | Description |
 |--------|-------------|
-| `make test` | Unit tests with race detector + coverage (seconds; `-short` skips the 5s backup sim) |
+| `make test` | Unit tests with race detector + coverage (seconds; hermetic — fakes + client-go fake clientset) |
 | `make coverage-check` | Verify coverage meets `COVERAGE_THRESHOLD` (default 40%) |
 | `make e2e-deps` | Ensure the Dapr control plane (placement + scheduler) is up |
 | `make e2e` | End-to-end: real Dapr sidecar + a kind cluster; deploys a PostgreSQL workload, verifies the role/DB on it + idempotent re-Put, then destroys the workload (minutes; needs Docker + Dapr CLI) |
@@ -159,7 +162,7 @@ Run `make help` to see all targets.
 | `make secrets` | gitleaks secret scan |
 | `make trivy-fs` | Trivy filesystem scan (vuln, secret, misconfig) |
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown (same engine GitHub renders with) |
-| `make static-check` | Composite quality gate (alignment + workflow lint + lint + vuln + secrets + trivy + mermaid) |
+| `make static-check` | Composite quality gate (env + alignment + workflow lint + lint + vuln + secrets + trivy + mermaid) |
 
 ### Local Infra & Containers
 
@@ -178,6 +181,7 @@ Run `make help` to see all targets.
 |--------|-------------|
 | `make ci` | Full local CI pipeline (mirrors GitHub Actions) |
 | `make ci-run` | Run the GitHub Actions workflow locally via [act](https://github.com/nektos/act) |
+| `make renovate-validate` | Validate `renovate.json` against the Renovate config schema |
 | `make release` | Create and push a new release tag (`vN.N.N`) |
 | `make version` | Print the current version (git tag) |
 
@@ -192,3 +196,11 @@ Run `make help` to see all targets.
 The `e2e` job runs `make e2e`, which `dapr init`s a real control plane, starts the state-store PostgreSQL, creates a kind cluster, runs the app under a Dapr sidecar, and asserts the recipe **actually deployed a PostgreSQL workload** (ready Deployment) and provisioned a role + database on it (the credentials authenticate over the Service's NodePort) — then re-Puts idempotently and `PostgresSQLDatabasesDelete` destroys the workload (kind + kubectl come from mise). The `docker` job builds the image and runs a blocking Trivy scan on every push; on a tag it publishes a cosign-signed `linux/amd64` image to `ghcr.io/andriykalashnykov/dapr-go-workflow-k8s`. Branch protection requires the `ci-pass` check before merging (including for Renovate automerge).
 
 > **Dapr runtime ≥ 1.18 is required.** go-sdk v1.15 / durabletask-go v0.12 fail activity invocation on older runtimes (`required metadata dapr-callee-app-id ... not found`). `make e2e` installs the version pinned by `DAPR_RUNTIME_VERSION` (default 1.18.0).
+
+## Contributing
+
+Contributions welcome — open a PR. Run `make ci` locally before pushing; CI gates every change on the `ci-pass` check.
+
+## License
+
+[MIT](LICENSE).

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "platformAutomerge is intentionally false (not the base-template true): main requires the `ci-pass` status check, and GitHub-native platform automerge can fire in the brief window before that check registers. PR-level automerge (automerge:true, automergeType:pr) waits for the check, so it is the race-safe choice here. Do not flip platformAutomerge to true."
+  ],
   "extends": [
     "config:best-practices",
     ":semanticCommitType(chore)"
@@ -88,8 +91,8 @@
       "groupName": "Dapr runtime"
     },
     {
-      "description": "Disable digest pinning for Makefile-tracked docker dev tools (e.g. minlag/mermaid-cli). config:best-practices' docker:pinDigests otherwise generates a pinDigest update that collides with the version bump on the same branch and silently drops it. These are dev/lint tools invoked via `docker run image:$(VERSION)`, not production runtime — version pinning is sufficient. Production pins (Dockerfile FROM) keep their digests. Scoped by file + datasource (the Makefile is the only docker pin outside the Dockerfile).",
-      "matchFileNames": ["Makefile"],
+      "description": "Disable digest pinning for every custom.regex-tracked docker ref: the Makefile's minlag/mermaid-cli dev tool AND the postgres workload image tracked in pkg/activities/config.go + .env.example. config:best-practices' docker:pinDigests generates a pinDigest update these customManagers cannot write back (their matchStrings capture only the tag, no currentDigest group), so the renovate/pin-dependencies branch errors on every run. Version pinning is sufficient here; the Dockerfile FROM pins (built-in dockerfile manager) keep their digests.",
+      "matchManagers": ["custom.regex"],
       "matchDatasources": ["docker"],
       "pinDigests": false
     }

--- a/run-postgres.sh
+++ b/run-postgres.sh
@@ -14,6 +14,7 @@ POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-daprrulz}"
 POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 POSTGRES_USER="${POSTGRES_USER:-postgres}"
 POSTGRES_DB="${POSTGRES_DB:-sample_state}"
+POSTGRES_STATE_IMAGE="${POSTGRES_STATE_IMAGE:-postgres:18-alpine}"
 
 echo "Starting database..."
 
@@ -28,7 +29,7 @@ docker run \
   -v "$SCRIPT_DIR/db/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh" \
   --rm \
   -d \
-  postgres
+  "$POSTGRES_STATE_IMAGE"
 
 # Wait until the init scripts have run and the target DB accepts connections —
 # daprd's state.postgresql component pings the DB on startup and fatals if it


### PR DESCRIPTION
## Summary

Applies the auto-applicable findings from a full `/project-review` (8 parallel skill agents: Makefile, CI, renovate, README, CLAUDE.md, Docker-harden Phase 0, test-coverage, architecture-diagram). Every HIGH/CRITICAL was fact-checked empirically before applying.

### CRITICAL
- **README fabricated a `go-chi/chi` router** — no `chi` in `go.mod`/`go.sum`; `server.go` uses stdlib `http.ServeMux` + Go 1.22 method/path patterns. Corrected.

### HIGH — CI correctness
- `static-check`/`build`/`test`/`e2e` gates missing `!failure() && !cancelled()` — an explicit `if:` strips the implicit `success()`, so a failed upstream no longer blocked dependents (build/test could run on a lint-broken tree).
- `cleanup-runs.yml` age-based deletion had **no open-PR exclusion** — an idle PR older than 7d lost its CI run → `mergeStateStatus=BLOCKED`, silently un-mergeable. Added `OPEN_SHAS` filter + `pull-requests: read`.

### HIGH — renovate
- `postgres` docker customManager captures a tag only (no digest group), so `docker:pinDigests` errored the `renovate/pin-dependencies` branch every run (confirmed via debug dry-run). Broadened the existing `pinDigests:false` rule from `Makefile` to all `custom.regex` docker refs.

### HIGH — docs
- README + CLAUDE.md both restated a fabricated "5s backup simulation / `go test -short`" — no such code exists. Removed.

### MEDIUM / LOW (auto-applied)
- Makefile: `check-env` STOPPER gate (first `static-check` prereq, proven RED); `renovate-validate` target; `image-run` port guard; `release` stages `version.txt` only.
- `run-postgres.sh`: pin the dev state-store image via Renovate-tracked `POSTGRES_STATE_IMAGE`.
- renovate: document `platformAutomerge:false`; enabled repo Dependabot **alerts** so `vulnerabilityAlerts` is live (security-updates stay disabled — Renovate-only).
- CI: `dorny/paths-filter` v3→v4; restore `specs/**`,`benchmarks/**` filter globs; name cache steps; rename e2e step.
- README: add kind/kubectl/Dapr CLI prerequisites; reference `POSTGRES_PASSWORD`'s source of truth instead of restating it; add Contributing/License; list the two new targets; `Go 1.26`→`1.26.4`.
- CLAUDE.md: add unit-vs-e2e test-pyramid timing; stop restating the drift-prone Dapr `1.18.0` literal.
- `.mise.toml`: correct a stale pre-workload-deploy "Service+Secret binding" comment.

### Declined (with rationale)
- **README C4-Context hero** — single-service scaffold; the Architecture flowchart already provides the container view.
- **release image-before-Release ordering restructure** — working release path; marginal benefit on a demo repo.

### Report-only follow-ups (not in this PR, per skill policy)
- Docker **base-image digest pinning** (`golang:1.26.4-bookworm`, `distroless/static-debian12:nonroot`) → `/harden-image-pipeline`.
- **pgx-admin Testcontainers integration layer** (currently e2e-only) → `/test-coverage-analysis`.

## Test plan
- [x] `make static-check` green (check-env + alignment + lint-ci + lint + vuln + secrets + trivy-fs + mermaid-lint)
- [x] `actionlint`, `shellcheck run-postgres.sh`, `renovate-config-validator --strict` all clean
- [x] `check-env` proven RED (missing `.env.example` → exit 1) and GREEN
- [x] both postgres image pins confirmed matched by the renovate customManager
- [ ] Watch CI on this PR to green
