### PR TITLE
chore: digest-pin base images (harden-image-pipeline)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Builder — version MUST match the `go` directive in go.mod and the `go` pin in
 # .mise.toml (enforced by `make check-go-alignment`).
-FROM golang:1.26.4-bookworm AS build
+FROM golang:1.26.4-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build
 
 WORKDIR /src
 
@@ -24,7 +24,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
         go build -trimpath -ldflags="-s -w" -o /out/healthcheck ./cmd/healthcheck
 
 # Runtime — distroless static, runs as the non-root `nonroot` user (UID 65532).
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+# Digest is the multi-arch manifest-LIST digest (buildx resolves the matching
+# arch), so pinning keeps the base reproducible without losing arch flexibility.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639 AS runtime
 
 ARG APP_INTERNAL_PORT=7999
 ENV APP_PORT=${APP_INTERNAL_PORT} \


### PR DESCRIPTION
## Summary

`/harden-image-pipeline` on an already-Phase-1+2-hardened repo (Trivy fs+image gates, cosign keyless signing, tag-gated GHCR publish, distroless non-root, Pattern A). The only real gap was **base-image digest pinning**.

- Pin `golang:1.26.4-bookworm` and `gcr.io/distroless/static-debian12:nonroot` to their **manifest-list `@sha256`** digests → reproducible builds; a re-pushed upstream tag can't silently swap the base. The distroless digest is the multi-arch **manifest-list** digest, so buildx still resolves the matching arch.
- Renovate's `dockerfile` manager tracks digest bumps; `golang` stays in the `Go toolchain` cross-manager group. `make check-go-alignment` still extracts `1.26.4` (grep stops before the `@`).

### Smoke test — deliberately NOT added (empirically justified)

The questionnaire picked "digest-pin + 5s smoke test", but I **omitted the smoke test** after verifying it would be red-by-construction: the app blocking-dials the Dapr sidecar at startup (`daprclient.NewClient()`, 5s deadline) and `os.Exit(1)`s without one — a bare `docker run` container **exits in ~5s** (verified). A crash-loop smoke would false-fail every tag push (the skill's "a probe that can't reach the app is WORSE than none"). Liveness+function are already covered by `make e2e` against a real sidecar on the same tag push; the existing `docker`-job comment already documents this.

## Test plan
- [x] `make check-go-alignment` (Go version still extracted past the `@digest`)
- [x] `hadolint Dockerfile` clean
- [x] `docker build` against the pinned digests succeeds
- [x] `renovate-config-validator --strict` passes
- [x] verified the app exits without a sidecar (so the smoke test is correctly omitted)
- [ ] Watch CI on this PR to green