### PR TITLE
docs: sync README + CLAUDE.md for the new integration test layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Toolchain and quality tools are managed by **mise** (`.mise.toml`); `make deps` 
 make ci          # deps + format + static-check + test + coverage-check + build
 make build       # CGO_ENABLED=0 GOOS=linux GOARCH=amd64 → ./cmd/main
 make test        # go test -race -coverprofile=coverage.out ./...
+make integration-test # pgx admin client vs a Testcontainers postgres:18-alpine (-tags=integration; needs Docker)
 make static-check# composite quality gate
 make e2e         # real end-to-end: kind + Postgres + Dapr, provisions & tears down
 make check-ports # fail early if a guarded host port (Postgres/app/grpc) is taken
@@ -67,7 +68,7 @@ make release     # validate semver, commit version.txt, tag, push
 
 Run a single test: `go test -run '^TestName$' ./pkg/<pkg>/...`.
 
-Two test layers: `make test` (unit — hermetic, fakes + client-go's in-memory fake clientset, runs in seconds) and `make e2e` (real end-to-end — `dapr init` control plane + a kind cluster + a deployed PostgreSQL workload, runs in minutes). There is no separate integration layer; the pgx-admin and workflow-orchestration paths are covered by `make e2e`.
+Three test layers: `make test` (unit — hermetic, fakes + client-go's in-memory fake clientset, runs in seconds), `make integration-test` (integration — the real pgx admin client against a Testcontainers `postgres:18-alpine` on a dynamic port, `//go:build integration`, needs Docker, runs in tens of seconds; NOT in `make ci`), and `make e2e` (real end-to-end — `dapr init` control plane + a kind cluster + a deployed PostgreSQL workload, runs in minutes). The pgx-admin SQL branches are covered by `make integration-test`; the deploy-rollout and workflow-orchestration funcs by `make e2e`.
 
 ### Local end-to-end loop (manual)
 
@@ -84,7 +85,7 @@ Because the recipe deploys a real workload, running it needs a **kubeconfig** fo
 
 ## Testing notes
 
-- **Unit-tested**: `pkg/recipes` (100%), `pkg/activities` activity funcs (via a fake `ActivityContext`) + the real `clientsetDeployer` (object creation, idempotency, `waitAndDiscover`, delete — via client-go's in-memory fake clientset in `kubeclient_test.go`), `pkg/server`, `cmd/healthcheck`. `COVERAGE_THRESHOLD` defaults to **40%** because the pgx admin client, the deploy rollout, and the workflow-orchestration funcs are covered by `make e2e`, not unit tests.
+- **Unit-tested**: `pkg/recipes` (100%), `pkg/activities` activity funcs (via a fake `ActivityContext`) + the real `clientsetDeployer` (object creation, idempotency, `waitAndDiscover`, delete — via client-go's in-memory fake clientset in `kubeclient_test.go`), `pkg/server`, `cmd/healthcheck`. `COVERAGE_THRESHOLD` defaults to **40%** because the pgx admin client is covered by `make integration-test` (Testcontainers, `//go:build integration`) and the deploy rollout + workflow-orchestration funcs by `make e2e` — not by the default (tag-excluded) unit build.
 - **`make e2e`** is the real end-to-end test (`e2e/e2e-test.sh`): it `dapr init`s a control plane, starts the state-store PostgreSQL, **creates a kind cluster**, runs the app under a Dapr sidecar (`KUBECONFIG` → kind), schedules `PostgresSQLDatabasesPut`, and verifies the recipe **actually deployed a PostgreSQL workload**: the Deployment has a ready replica, and the provisioned role authenticates to its database **on the deployed instance** (via node-IP:NodePort). It then re-Puts (asserting idempotent reuse with no orphan) and runs `PostgresSQLDatabasesDelete`, asserting the Deployment/Service/Secret are gone. It manages its own kind cluster (`E2E_KIND_KEEP=1` keeps it). Runs in CI (the `e2e` job; kind + kubectl come from mise) and locally.
 - **Dapr runtime ≥ 1.18 is required** (pinned via `DAPR_RUNTIME_VERSION` in `.env.example` / the Makefile). The `dapr/go-sdk` + `durabletask-go` versions in `go.mod` fail activity invocation on older runtimes with `required metadata dapr-callee-app-id ... not found`.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Run `make help` to see all targets.
 |--------|-------------|
 | `make test` | Unit tests with race detector + coverage (seconds; hermetic — fakes + client-go fake clientset) |
 | `make coverage-check` | Verify coverage meets `COVERAGE_THRESHOLD` (default 40%) |
+| `make integration-test` | Integration tests for the pgx admin client against a real `postgres:18-alpine` via Testcontainers (`-tags=integration`; tens of seconds; needs Docker). Not part of `make ci` |
 | `make e2e-deps` | Ensure the Dapr control plane (placement + scheduler) is up |
 | `make e2e` | End-to-end: real Dapr sidecar + a kind cluster; deploys a PostgreSQL workload, verifies the role/DB on it + idempotent re-Put, then destroys the workload (minutes; needs Docker + Dapr CLI) |
 
@@ -189,11 +190,11 @@ Run `make help` to see all targets.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | push to `main`, `v*` tags, PRs | `changes` → `static-check` / `build` / `test` / `e2e` → `docker` → `ci-pass` |
+| `ci.yml` | push to `main`, `v*` tags, PRs | `changes` → `static-check` / `build` / `test` / `integration` / `e2e` → `docker` → `ci-pass` |
 | `release.yml` | `v*.*.*` tags | reuses `ci.yml`, then GoReleaser publishes binaries + GitHub Release |
 | `cleanup-runs.yml` | weekly / dispatch | prunes old workflow runs and caches |
 
-The `e2e` job runs `make e2e`, which `dapr init`s a real control plane, starts the state-store PostgreSQL, creates a kind cluster, runs the app under a Dapr sidecar, and asserts the recipe **actually deployed a PostgreSQL workload** (ready Deployment) and provisioned a role + database on it (the credentials authenticate over the Service's NodePort) — then re-Puts idempotently and `PostgresSQLDatabasesDelete` destroys the workload (kind + kubectl come from mise). The `docker` job builds the image and runs a blocking Trivy scan on every push; on a tag it publishes a cosign-signed `linux/amd64` image to `ghcr.io/andriykalashnykov/dapr-go-workflow-k8s`. Branch protection requires the `ci-pass` check before merging (including for Renovate automerge).
+The `e2e` job runs `make e2e`, which `dapr init`s a real control plane, starts the state-store PostgreSQL, creates a kind cluster, runs the app under a Dapr sidecar, and asserts the recipe **actually deployed a PostgreSQL workload** (ready Deployment) and provisioned a role + database on it (the credentials authenticate over the Service's NodePort) — then re-Puts idempotently and `PostgresSQLDatabasesDelete` destroys the workload (kind + kubectl come from mise). The `integration` job runs `make integration-test` — the real pgx admin client against a Testcontainers `postgres:18-alpine` (SQL-branch coverage in seconds, no cluster). The `docker` job builds the image and runs a blocking Trivy scan on every push; on a tag it publishes a cosign-signed `linux/amd64` image to `ghcr.io/andriykalashnykov/dapr-go-workflow-k8s`. Branch protection requires the `ci-pass` check before merging (including for Renovate automerge).
 
 > **Dapr runtime ≥ 1.18 is required.** go-sdk v1.15 / durabletask-go v0.12 fail activity invocation on older runtimes (`required metadata dapr-callee-app-id ... not found`). `make e2e` installs the version pinned by `DAPR_RUNTIME_VERSION` (default 1.18.0).
 


### PR DESCRIPTION
Closing-audit follow-up to #64: that PR added `make integration-test` + the CI `integration` job but left the prose docs stale — CLAUDE.md still said *"there is no separate integration layer"* (a line added in #62 and invalidated by #64).

- **CLAUDE.md**: two-layer → **three-layer test pyramid** (unit / integration / e2e); the coverage-threshold note now credits `make integration-test` for the pgx-admin path; commands block lists it.
- **README**: `integration-test` row in the Testing table; the CI/CD job graph + prose now include the `integration` job.

Docs-only, but CLAUDE.md is re-included as `code` in the paths filter, so full CI runs.

## Test plan
- [x] no stale "no separate integration layer" / "Two test layers" remain
- [x] `make mermaid-lint` clean
- [ ] Watch CI to green